### PR TITLE
linux5*-tkg: Fix finding config fragments when $_where is a symlink

### DIFF
--- a/linux54-tkg/PKGBUILD
+++ b/linux54-tkg/PKGBUILD
@@ -757,7 +757,7 @@ prepare() {
 
   if [ true = "$_config_fragments" ]; then
     local fragments=()
-    mapfile -d '' -t fragments < <(find "$_where" -type f -name "*.myfrag" -print0)
+    mapfile -d '' -t fragments < <(find "$_where"/ -type f -name "*.myfrag" -print0)
 
     if [ true = "$_config_fragments_no_confirm" ]; then
       printf 'Using config fragment %s\n' "${fragments[@]#$_where/}"

--- a/linux56-tkg/PKGBUILD
+++ b/linux56-tkg/PKGBUILD
@@ -811,7 +811,7 @@ prepare() {
 
   if [ true = "$_config_fragments" ]; then
     local fragments=()
-    mapfile -d '' -t fragments < <(find "$_where" -type f -name "*.myfrag" -print0)
+    mapfile -d '' -t fragments < <(find "$_where"/ -type f -name "*.myfrag" -print0)
 
     if [ true = "$_config_fragments_no_confirm" ]; then
       printf 'Using config fragment %s\n' "${fragments[@]#$_where/}"

--- a/linux57-tkg/PKGBUILD
+++ b/linux57-tkg/PKGBUILD
@@ -810,7 +810,7 @@ prepare() {
 
   if [ true = "$_config_fragments" ]; then
     local fragments=()
-    mapfile -d '' -t fragments < <(find "$_where" -type f -name "*.myfrag" -print0)
+    mapfile -d '' -t fragments < <(find "$_where"/ -type f -name "*.myfrag" -print0)
 
     if [ true = "$_config_fragments_no_confirm" ]; then
       printf 'Using config fragment %s\n' "${fragments[@]#$_where/}"


### PR DESCRIPTION
I personally prefer to symlink the folder containing the kernel `PKGBUILD`
among other files to somewhere else for quicker access and with that
setup `.myfrag` config fragments were not getting found earlier.