### PR TITLE
linux57/58-tkg: Add _noccache to default cfg.

### DIFF
--- a/linux57-tkg/customization.cfg
+++ b/linux57-tkg/customization.cfg
@@ -23,6 +23,9 @@ _OPTIPROFILE=""
 # Set to true to bypass makepkg.conf and use all available threads for compilation. False will respect your makepkg.conf options.
 _force_all_threads="true"
 
+# Set to true to prevent ccache from being used and set CONFIG_GCC_PLUGINS=y (which needs to be disabled for ccache to work properly)
+_noccache="false"
+
 # Set to true to use modprobed db to clean config from unneeded modules. Speeds up compilation considerably. Requires root - https://wiki.archlinux.org/index.php/Modprobed-db
 # !!!! Make sure to have a well populated db !!!! - Leave empty to be asked about it at build time
 _modprobeddb="false"

--- a/linux58-rc-tkg/customization.cfg
+++ b/linux58-rc-tkg/customization.cfg
@@ -23,6 +23,9 @@ _OPTIPROFILE=""
 # Set to true to bypass makepkg.conf and use all available threads for compilation. False will respect your makepkg.conf options.
 _force_all_threads="true"
 
+# Set to true to prevent ccache from being used and set CONFIG_GCC_PLUGINS=y (which needs to be disabled for ccache to work properly)
+_noccache="false"
+
 # Set to true to use modprobed db to clean config from unneeded modules. Speeds up compilation considerably. Requires root - https://wiki.archlinux.org/index.php/Modprobed-db
 # !!!! Make sure to have a well populated db !!!! - Leave empty to be asked about it at build time
 _modprobeddb="false"


### PR DESCRIPTION
These lines seem to have been left behind. [`linux56-tkg`](https://github.com/Frogging-Family/linux-tkg/blob/14df411ac59ed7cef254a21732f27b904c336d99/linux56-tkg/customization.cfg#L26-L27) for reference.