### PR TITLE
gitignore: Ignore all package extensions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 *.pkg
 *.bak
 *.tar.gz
-*.tar.zst
+*.pkg.*
 *.old
 *.db
 *.files


### PR DESCRIPTION
[`makepkg.conf(5)`](https://www.archlinux.org/pacman/makepkg.conf.5.html) supports several different package extensions. The current `.gitignore` accounts for zstd and gz compression, but not for a lack of compression (`*.tar`), which is useful for smaller build times. Rather than adding another extension, I think it's best to match the `.pkg` part. I can add `*.src.*` too, it's just unclear to me whether or not that's useful here.