### PR TITLE
linux57: add interactive prompt for _misc_adds

### DIFF
--- a/linux57-tkg/customization.cfg
+++ b/linux57-tkg/customization.cfg
@@ -80,7 +80,7 @@ _ftracedisable="false"
 _numadisable="false"
 
 # Set to "true" to enable misc additions - May contain temporary fixes pending upstream or changes that can break on non-Arch - Kernel default is "true"
-_misc_adds="true"
+_misc_adds=""
 
 # Set to "1" to use CattaRappa mode (enabling full tickless), "2" for tickless idle only, or "0" for periodic ticks.
 # Full tickless can give higher performances in various cases but, depending on hardware, lower consistency. Just tickless idle can perform better on some platforms (mostly AMD based).

--- a/linux57-tkg/linux57-tkg-config/prepare
+++ b/linux57-tkg/linux57-tkg-config/prepare
@@ -142,7 +142,15 @@ _tkg_srcprep() {
   msg2 "Applying glitched base patch"
   patch -Np1 -i "$srcdir"/0003-glitched-base.patch
 
-  if [ "$_misc_adds" = "true" ]; then
+  if [ -z $_misc_adds ]; then
+    plain "Enable misc additions ? May contain temporary fixes pending upstream or changes that can break on non-Arch. "
+    read -rp "`echo $'    > [Y]/n : '`" _interactive_misc_adds;
+    if [ "$_interactive_misc_adds" != "n" ] && [ "$_interactive_misc_adds" != "N" ]; then
+      _misc_adds="true"
+    fi
+  fi
+
+  if [ "$_misc_adds" == "true" ]; then
     msg2 "Applying misc additions patch"
     patch -Np1 -i "$srcdir"/0012-misc-additions.patch
   fi


### PR DESCRIPTION
I think this is a quality of life improvement for the end user, especially Ubuntu guys (maybe Fedora, I started working on it, I will see if it gets those leak errors), since they will for sure go through the compile process once with `_misc_adds=true`, see that it doesn't work. Try to find out why, and then maybe end up trying `_misc_adds=false`. 

I believe having the prompt would help. What do you think ?

Edit: Fedora gets the leaky TTY too, maybe I should work on a fix for the leak, like PDS actually