### PR TITLE
Accept default options to "make localmodconfig"

### DIFF
--- a/linux54-tkg/linux54-tkg-config/prepare
+++ b/linux54-tkg/linux54-tkg-config/prepare
@@ -640,7 +640,7 @@ _tkg_srcprep() {
   fi
   if [[ "$CONDITIONMPDB" =~ [yY] ]] || [ "$_modprobeddb" == "true" ]; then
     sudo modprobed-db recall
-    make localmodconfig
+    yes "" | make localmodconfig
   fi
 
   if [ true = "$_config_fragments" ]; then

--- a/linux57-tkg/linux57-tkg-config/prepare
+++ b/linux57-tkg/linux57-tkg-config/prepare
@@ -803,7 +803,7 @@ _tkg_srcprep() {
   fi
   if [[ "$CONDITIONMPDB" =~ [yY] ]] || [ "$_modprobeddb" = "true" ]; then
     sudo modprobed-db recall
-    make localmodconfig
+    yes "" | make localmodconfig
   fi
 
   if [ true = "$_config_fragments" ]; then

--- a/linux58-tkg/linux58-tkg-config/prepare
+++ b/linux58-tkg/linux58-tkg-config/prepare
@@ -800,7 +800,7 @@ _tkg_srcprep() {
   fi
   if [[ "$CONDITIONMPDB" =~ [yY] ]] || [ "$_modprobeddb" = "true" ]; then
     sudo modprobed-db recall
-    make localmodconfig
+    yes "" | make localmodconfig
   fi
 
   if [ true = "$_config_fragments" ]; then

--- a/linux59-rc-tkg/linux59-tkg-config/prepare
+++ b/linux59-rc-tkg/linux59-tkg-config/prepare
@@ -798,7 +798,7 @@ _tkg_srcprep() {
   fi
   if [[ "$CONDITIONMPDB" =~ [yY] ]] || [ "$_modprobeddb" = "true" ]; then
     sudo modprobed-db recall
-    make localmodconfig
+    yes "" | make localmodconfig
   fi
 
   if [ true = "$_config_fragments" ]; then


### PR DESCRIPTION
This PR pipes `yes ""` to `make localmodconfig`, to alleviate Tk-Glitch/PKGBUILDS#404. I deem this to be an acceptable solution as this seems to be "not our bug" as this affects more than TkG, and the options that are prompted for seem to be pretty insignificant.