### PR TITLE
Install the TkG configuration used to the system

### DIFF
--- a/linux54-tkg/PKGBUILD
+++ b/linux54-tkg/PKGBUILD
@@ -105,7 +105,7 @@ url="http://www.kernel.org/"
 license=('GPL2')
 makedepends=('xmlto' 'docbook-xsl' 'kmod' 'inetutils' 'bc' 'libelf' 'patchutils' 'flex' 'python-sphinx' 'python-sphinx_rtd_theme' 'graphviz' 'imagemagick' 'git')
 optdepends=('schedtool')
-options=('!strip')
+options=('!strip' 'docs')
 source=("https://www.kernel.org/pub/linux/kernel/v5.x/linux-${_basekernel}.tar.xz"
         "https://www.kernel.org/pub/linux/kernel/v5.x/patch-${pkgver}.xz"
         "https://raw.githubusercontent.com/graysky2/kernel_gcc_patch/master/enable_additional_cpu_optimizations_for_gcc_v10.1%2B_kernel_v4.19-v5.4.patch"
@@ -194,6 +194,9 @@ build() {
     msg2 'ccache was found and will be used'
   fi
 
+  # document the TkG variables, excluding "_", "_EXT_CONFIG_PATH", and "_where".
+  declare -p | cut -d ' ' -f 3 | grep -P '^_(?!=|EXT_CONFIG_PATH|where)' > "${srcdir}/customization-full.cfg"
+
   # build!
   _runtime=$( time ( schedtool -B -n 1 -e ionice -n 1 make $_force_all_threads LOCALVERSION= bzImage modules 2>&1 ) 3>&1 1>&2 2>&3 ) || _runtime=$( time ( make $_force_all_threads LOCALVERSION= bzImage modules 2>&1 ) 3>&1 1>&2 2>&3 )
 }
@@ -234,6 +237,9 @@ hackbase() {
   sed -e "s|cleanup|${pkgbase}-cleanup|g" "${srcdir}"/90-cleanup.hook |
     install -Dm644 /dev/stdin "${pkgdir}/usr/share/libalpm/hooks/90-${pkgbase}.hook"
   install -Dm755 "${srcdir}"/cleanup "${pkgdir}/usr/share/libalpm/scripts/${pkgbase}-cleanup"
+
+  # install customization file, for reference
+  install -Dm644 "${srcdir}"/customization-full.cfg "${pkgdir}/usr/share/doc/${pkgbase}/customization.cfg"
 
   msg2 "Fixing permissions..."
   chmod -Rc u=rwX,go=rX "$pkgdir"

--- a/linux54-tkg/README.md
+++ b/linux54-tkg/README.md
@@ -2,7 +2,7 @@
 
 A custom Linux kernel 5.4.y with specific PDS, MuQSS and BMQ CPU schedulers related patchsets selector (stock CFS is also an option) and added tweaks for a nice interactivity/performance balance, aiming for the best gaming experience.
 
-Various personalization options available and userpatches support (put your own patches in the same dir as the PKGBUILD, with the ".mypatch" extension.
+Various personalization options available and userpatches support (put your own patches in the same dir as the PKGBUILD, with the ".mypatch" extension). The options built with are installed to `/usr/share/doc/$pkgbase/customization.cfg`, where `$pkgbase` is the package name.
 
 MuQSS : http://ck-hack.blogspot.com/
 

--- a/linux57-tkg/PKGBUILD
+++ b/linux57-tkg/PKGBUILD
@@ -44,7 +44,7 @@ url="http://www.kernel.org/"
 license=('GPL2')
 makedepends=('xmlto' 'docbook-xsl' 'kmod' 'inetutils' 'bc' 'libelf' 'pahole' 'patchutils' 'flex' 'python-sphinx' 'python-sphinx_rtd_theme' 'graphviz' 'imagemagick' 'git')
 optdepends=('schedtool')
-options=('!strip')
+options=('!strip' 'docs')
 source=("https://www.kernel.org/pub/linux/kernel/v5.x/linux-${_basekernel}.tar.xz"
         "https://www.kernel.org/pub/linux/kernel/v5.x/patch-${pkgver}.xz"
         "https://raw.githubusercontent.com/graysky2/kernel_gcc_patch/master/enable_additional_cpu_optimizations_for_gcc_v10.1%2B_kernel_v5.7%2B.patch"
@@ -137,6 +137,9 @@ build() {
     msg2 'ccache was found and will be used'
   fi
 
+  # document the TkG variables, excluding "_", "_EXT_CONFIG_PATH", and "_where".
+  declare -p | cut -d ' ' -f 3 | grep -P '^_(?!=|EXT_CONFIG_PATH|where)' > "${srcdir}/customization-full.cfg"
+
   # build!
   _runtime=$( time ( schedtool -B -n 1 -e ionice -n 1 make ${_force_all_threads} LOCALVERSION= bzImage modules 2>&1 ) 3>&1 1>&2 2>&3 ) || _runtime=$( time ( make ${_force_all_threads} LOCALVERSION= bzImage modules 2>&1 ) 3>&1 1>&2 2>&3 )
 }
@@ -178,6 +181,9 @@ hackbase() {
   sed -e "s|cleanup|${pkgbase}-cleanup|g" "${srcdir}"/90-cleanup.hook |
     install -Dm644 /dev/stdin "${pkgdir}/usr/share/libalpm/hooks/90-${pkgbase}.hook"
   install -Dm755 "${srcdir}"/cleanup "${pkgdir}/usr/share/libalpm/scripts/${pkgbase}-cleanup"
+
+  # install customization file, for reference
+  install -Dm644 "${srcdir}"/customization-full.cfg "${pkgdir}/usr/share/doc/${pkgbase}/customization.cfg"
 }
 
 hackheaders() {

--- a/linux57-tkg/README.md
+++ b/linux57-tkg/README.md
@@ -2,7 +2,7 @@
 
 A custom Linux kernel 5.7.y with specific PDS, MuQSS and Project C / BMQ CPU schedulers related patchsets selector (stock CFS is also an option) and added tweaks for a nice interactivity/performance balance, aiming for the best gaming experience.
 
-Various personalization options available and userpatches support (put your own patches in the same dir as the PKGBUILD, with the ".mypatch" extension.
+Various personalization options available and userpatches support (put your own patches in the same dir as the PKGBUILD, with the ".mypatch" extension). The options built with are installed to `/usr/share/doc/$pkgbase/customization.cfg`, where `$pkgbase` is the package name.
 
 MuQSS : http://ck-hack.blogspot.com/
 

--- a/linux58-tkg/PKGBUILD
+++ b/linux58-tkg/PKGBUILD
@@ -50,7 +50,7 @@ url="http://www.kernel.org/"
 license=('GPL2')
 makedepends=('xmlto' 'docbook-xsl' 'kmod' 'inetutils' 'bc' 'libelf' 'pahole' 'patchutils' 'flex' 'python-sphinx' 'python-sphinx_rtd_theme' 'graphviz' 'imagemagick' 'git')
 optdepends=('schedtool')
-options=('!strip')
+options=('!strip' 'docs')
 source=("https://www.kernel.org/pub/linux/kernel/v5.x/linux-${_basekernel}.tar.xz"
         "https://www.kernel.org/pub/linux/kernel/v5.x/patch-${pkgver}.xz"
         "https://raw.githubusercontent.com/graysky2/kernel_gcc_patch/master/enable_additional_cpu_optimizations_for_gcc_v10.1%2B_kernel_v5.8%2B.patch"
@@ -137,6 +137,9 @@ build() {
     msg2 'ccache was found and will be used'
   fi
 
+  # document the TkG variables, excluding "_", "_EXT_CONFIG_PATH", and "_where".
+  declare -p | cut -d ' ' -f 3 | grep -P '^_(?!=|EXT_CONFIG_PATH|where)' > "${srcdir}/customization-full.cfg"
+
   # build!
   _runtime=$( time ( schedtool -B -n 1 -e ionice -n 1 make ${_force_all_threads} LOCALVERSION= bzImage modules 2>&1 ) 3>&1 1>&2 2>&3 ) || _runtime=$( time ( make ${_force_all_threads} LOCALVERSION= bzImage modules 2>&1 ) 3>&1 1>&2 2>&3 )
 }
@@ -178,6 +181,9 @@ hackbase() {
   sed -e "s|cleanup|${pkgbase}-cleanup|g" "${srcdir}"/90-cleanup.hook |
     install -Dm644 /dev/stdin "${pkgdir}/usr/share/libalpm/hooks/90-${pkgbase}.hook"
   install -Dm755 "${srcdir}"/cleanup "${pkgdir}/usr/share/libalpm/scripts/${pkgbase}-cleanup"
+
+  # install customization file, for reference
+  install -Dm644 "${srcdir}"/customization-full.cfg "${pkgdir}/usr/share/doc/${pkgbase}/customization.cfg"
 }
 
 hackheaders() {

--- a/linux58-tkg/README.md
+++ b/linux58-tkg/README.md
@@ -10,7 +10,7 @@ PDS-mq was originally created by Alfred Chen : http://cchalpha.blogspot.com/
 
 While he dropped it with kernel 5.1 in favor of its BMQ evolution/rework, my pretty bad gaming experiences with BMQ up to this point convinced me to keep PDS afloat for as long as it'll make sense/I'll be able to.
 
-Various personalization options available and userpatches support (put your own patches in the same dir as the PKGBUILD, with the ".mypatch" extension.
+Various personalization options available and userpatches support (put your own patches in the same dir as the PKGBUILD, with the ".mypatch" extension). The options built with are installed to `/usr/share/doc/$pkgbase/customization.cfg`, where `$pkgbase` is the package name.
 
 Comes with a slightly modified Arch config asking for a few core personalization settings at compilation time.
 If you want to streamline your kernel config for lower footprint and faster compilations : https://wiki.archlinux.org/index.php/Modprobed-db

--- a/linux59-rc-tkg/PKGBUILD
+++ b/linux59-rc-tkg/PKGBUILD
@@ -50,7 +50,7 @@ url="http://www.kernel.org/"
 license=('GPL2')
 makedepends=('xmlto' 'docbook-xsl' 'kmod' 'inetutils' 'bc' 'libelf' 'pahole' 'patchutils' 'flex' 'python-sphinx' 'python-sphinx_rtd_theme' 'graphviz' 'imagemagick' 'git')
 optdepends=('schedtool')
-options=('!strip')
+options=('!strip' 'docs')
 source=("https://git.kernel.org/torvalds/t/linux-${_basekernel}-${_sub}.tar.gz"
         #"https://www.kernel.org/pub/linux/kernel/v5.x/patch-${pkgver}.xz"
         "https://raw.githubusercontent.com/graysky2/kernel_gcc_patch/master/enable_additional_cpu_optimizations_for_gcc_v10.1%2B_kernel_v5.8%2B.patch"
@@ -132,6 +132,9 @@ build() {
     msg2 'ccache was found and will be used'
   fi
 
+  # document the TkG variables, excluding "_", "_EXT_CONFIG_PATH", and "_where".
+  declare -p | cut -d ' ' -f 3 | grep -P '^_(?!=|EXT_CONFIG_PATH|where)' > "${srcdir}/customization-full.cfg"
+
   # build!
   _runtime=$( time ( schedtool -B -n 1 -e ionice -n 1 make ${_force_all_threads} LOCALVERSION= bzImage modules 2>&1 ) 3>&1 1>&2 2>&3 ) || _runtime=$( time ( make ${_force_all_threads} LOCALVERSION= bzImage modules 2>&1 ) 3>&1 1>&2 2>&3 )
 }
@@ -173,6 +176,9 @@ hackbase() {
   sed -e "s|cleanup|${pkgbase}-cleanup|g" "${srcdir}"/90-cleanup.hook |
     install -Dm644 /dev/stdin "${pkgdir}/usr/share/libalpm/hooks/90-${pkgbase}.hook"
   install -Dm755 "${srcdir}"/cleanup "${pkgdir}/usr/share/libalpm/scripts/${pkgbase}-cleanup"
+
+  # install customization file, for reference
+  install -Dm644 "${srcdir}"/customization-full.cfg "${pkgdir}/usr/share/doc/${pkgbase}/customization.cfg"
 }
 
 hackheaders() {

--- a/linux59-rc-tkg/README.md
+++ b/linux59-rc-tkg/README.md
@@ -5,7 +5,7 @@
 
 A custom Linux kernel 5.9 RC with added tweaks for a nice interactivity/performance balance, aiming for the best gaming experience.
 
-Various personalization options available and userpatches support (put your own patches in the same dir as the PKGBUILD, with the ".mypatch" extension.
+Various personalization options available and userpatches support (put your own patches in the same dir as the PKGBUILD, with the ".mypatch" extension). The options built with are installed to `/usr/share/doc/$pkgbase/customization.cfg`, where `$pkgbase` is the package name.
 
 Comes with a slightly modified Arch config asking for a few core personalization settings at compilation time.
 If you want to streamline your kernel config for lower footprint and faster compilations : https://wiki.archlinux.org/index.php/Modprobed-db


### PR DESCRIPTION
This pull request adds basic functionality for saving TkG variables (variables preceded with a `_`) to a file, and installing that file to the system. This can be useful for testing different kernel configurations, and seeing what the current version was compiled with. I have only implemented this for 5.7 as there are some design concerns that are up in the air:
- As is, `hackheaders` removes documentation from the package, so the only "documentation" produced by linux-tkg in this PR is `/usr/share/doc/${pkgbase}/customization.cfg`. As such, if one has `options=(!docs)` in their `makepkg.conf`, here it would only serve to strip that `customization.cfg`, so I have overrode that.
  - Is it desired behavior to produce this file if even if someone has `options=(!docs)`?
  - Would this file belong in `/usr/share/doc/` at all?
- Should this functionality be put behind a configuration variable?
  - Does this functionality belong here at all?
- This includes the path in which the package was compiled, which is potentially sensitive information, considering people can share packages.
- Currently, this includes some variables which are "internal" to the script. Is this acceptable?

These aren't questions I all expect answers to, I'm just laying out my thoughts as this is currently an RFC PR.

[Here](https://pastebin.com/66Ms7t7e) is an example of the file installed to the system.