### PR TITLE
Fix certificate issue on Debian

### DIFF
--- a/linux58-tkg/customization.cfg
+++ b/linux58-tkg/customization.cfg
@@ -1,6 +1,6 @@
 # linux58-TkG config file
 
-# Linux distribution you are using, options are "Arch" (default), "Ubuntu"
+# Linux distribution you are using, options are "Arch" (default), "Debian" or "Ubuntu"
 _distro="Arch"
 
 #### MISC OPTIONS #### 

--- a/linux58-tkg/install.sh
+++ b/linux58-tkg/install.sh
@@ -46,7 +46,7 @@ if [ "$1" = "install" ] || [ "$1" = "config" ]; then
 
   source linux*-tkg-config/prepare
 
-  if [ $1 = "install" ] && [[ "$_distro" != "Ubuntu" || "$_distro" != "Debian" ]]; then
+  if [ $1 = "install" ] && [[ "$_distro" != "Ubuntu" && "$_distro" != "Debian" ]]; then
     msg2 "Variable \"_distro\" in \"customization.cfg\" hasn't been set to \"Debian\" or \"Ubuntu\""
     msg2 "This script can only install custom kernels for Ubuntu and Debian derivatives. Exiting..."
     exit 0

--- a/linux58-tkg/install.sh
+++ b/linux58-tkg/install.sh
@@ -46,13 +46,13 @@ if [ "$1" = "install" ] || [ "$1" = "config" ]; then
 
   source linux*-tkg-config/prepare
 
-  if [ $1 = "install" ] && [ "$_distro" != "Ubuntu" ]; then
-    msg2 "Variable \"_distro\" in \"customization.cfg\" hasn't been set to \"Ubuntu\""
+  if [ $1 = "install" ] && [ "$_distro" != "Ubuntu" ] && [ "$_distro" != "Debian" ]; then
+    msg2 "Variable \"_distro\" in \"customization.cfg\" hasn't been set to \"Debian\" or \"Ubuntu\""
     msg2 "This script can only install custom kernels for Ubuntu and Debian derivatives. Exiting..."
     exit 0
   fi
 
-  if [ "$_distro" = "Ubuntu" ]; then
+  if [ "$_distro" = "Debian" ] || [ "$_distro" = "Ubuntu" ]; then
     msg2 "Installing dependencies"
     sudo apt install git build-essential kernel-package fakeroot libncurses5-dev libssl-dev ccache bison flex
   else
@@ -105,7 +105,7 @@ if [ "$1" = "install" ] || [ "$1" = "config" ]; then
 
   msg2 "Copying current kernel's config and running make oldconfig..."
   cp /boot/config-`uname -r` .config
-  if [ "$_distro" = "Ubuntu" ]; then #Help Debian cert problem.
+  if [ "$_distro" = "Debian" ]; then #Help Debian cert problem.
     sed -i -e 's#CONFIG_SYSTEM_TRUSTED_KEYS="debian/certs/test-signing-certs.pem"#CONFIG_SYSTEM_TRUSTED_KEYS=""#g' .config
   fi
   yes '' | make oldconfig
@@ -135,7 +135,7 @@ if [ "$1" = "install" ]; then
 
   # ccache
   if [ "$_noccache" != "true" ]; then
-    if [ "$_distro" = "Ubuntu" ] && dpkg -l ccache > /dev/null; then
+    if [[ "$_distro" = "Ubuntu" ] || [ "$_distro" = "Debian" ]] && dpkg -l ccache > /dev/null; then
       export PATH="/usr/lib/ccache/bin/:$PATH"
       export CCACHE_SLOPPINESS="file_macro,locale,time_macros"
       export CCACHE_NOHASHDIR="true"
@@ -148,7 +148,7 @@ if [ "$1" = "install" ]; then
     _kernel_flavor="tkg-${_cpusched}"
   fi
 
-  if [ "$_distro" = "Ubuntu" ]; then
+  if [ "$_distro" = "Ubuntu" ] || [ "$_distro" = "Debian" ]; then
     if make -j ${_thread_num} deb-pkg LOCALVERSION=-${_kernel_flavor}; then
       msg2 "Building successfully finished!"
       read -p "Do you want to install the new Kernel ? y/[n]: " _install

--- a/linux58-tkg/install.sh
+++ b/linux58-tkg/install.sh
@@ -74,6 +74,10 @@ if [ "$1" = "install" ] || [ "$1" = "config" ]; then
     git checkout --force linux-$_basekernel.y
     git clean -f -d -x
     git pull
+    if [ "$_distro" = "Ubuntu" ]; then #Help Debian cert problem.
+	        sed -i -e 's#CONFIG_SYSTEM_TRUSTED_KEYS="debian/certs/test-signing-certs.pem"#CONFIG_SYSTEM_TRUSTED_KEYS=""#g' "$_where"/linux${_basekernel//.}-tkg-config/config.x86_64
+	        cp "$_where"/linux${_basekernel//.}-tkg-config/config.x86_64 "$_where"/linux-${_basekernel}/.config
+    fi
     msg2 "Done" 
     cd "$_where"
   else

--- a/linux58-tkg/install.sh
+++ b/linux58-tkg/install.sh
@@ -46,7 +46,7 @@ if [ "$1" = "install" ] || [ "$1" = "config" ]; then
 
   source linux*-tkg-config/prepare
 
-  if [ $1 = "install" ] && [ "$_distro" != "Ubuntu" || "$_distro" != "Debian" ]; then
+  if [ $1 = "install" ] && [[ "$_distro" != "Ubuntu" || "$_distro" != "Debian" ]]; then
     msg2 "Variable \"_distro\" in \"customization.cfg\" hasn't been set to \"Debian\" or \"Ubuntu\""
     msg2 "This script can only install custom kernels for Ubuntu and Debian derivatives. Exiting..."
     exit 0

--- a/linux58-tkg/install.sh
+++ b/linux58-tkg/install.sh
@@ -74,10 +74,6 @@ if [ "$1" = "install" ] || [ "$1" = "config" ]; then
     git checkout --force linux-$_basekernel.y
     git clean -f -d -x
     git pull
-    if [ "$_distro" = "Ubuntu" ]; then #Help Debian cert problem.
-	        sed -i -e 's#CONFIG_SYSTEM_TRUSTED_KEYS="debian/certs/test-signing-certs.pem"#CONFIG_SYSTEM_TRUSTED_KEYS=""#g' "$_where"/linux${_basekernel//.}-tkg-config/config.x86_64
-	        cp "$_where"/linux${_basekernel//.}-tkg-config/config.x86_64 "$_where"/linux-${_basekernel}/.config
-    fi
     msg2 "Done" 
     cd "$_where"
   else
@@ -109,6 +105,9 @@ if [ "$1" = "install" ] || [ "$1" = "config" ]; then
 
   msg2 "Copying current kernel's config and running make oldconfig..."
   cp /boot/config-`uname -r` .config
+  if [ "$_distro" = "Ubuntu" ]; then #Help Debian cert problem.
+    sed -i -e 's#CONFIG_SYSTEM_TRUSTED_KEYS="debian/certs/test-signing-certs.pem"#CONFIG_SYSTEM_TRUSTED_KEYS=""#g' .config
+  fi
   yes '' | make oldconfig
   msg2 "Done"
 

--- a/linux58-tkg/install.sh
+++ b/linux58-tkg/install.sh
@@ -135,7 +135,7 @@ if [ "$1" = "install" ]; then
 
   # ccache
   if [ "$_noccache" != "true" ]; then
-    if [[ "$_distro" = "Ubuntu" ] || [ "$_distro" = "Debian" ]] && dpkg -l ccache > /dev/null; then
+    if [[ "$_distro" = "Ubuntu"  || "$_distro" = "Debian" ]] && dpkg -l ccache > /dev/null; then
       export PATH="/usr/lib/ccache/bin/:$PATH"
       export CCACHE_SLOPPINESS="file_macro,locale,time_macros"
       export CCACHE_NOHASHDIR="true"

--- a/linux58-tkg/install.sh
+++ b/linux58-tkg/install.sh
@@ -46,7 +46,7 @@ if [ "$1" = "install" ] || [ "$1" = "config" ]; then
 
   source linux*-tkg-config/prepare
 
-  if [ $1 = "install" ] && [ "$_distro" != "Ubuntu" ] && [ "$_distro" != "Debian" ]; then
+  if [ $1 = "install" ] && [ "$_distro" != "Ubuntu" || "$_distro" != "Debian" ]; then
     msg2 "Variable \"_distro\" in \"customization.cfg\" hasn't been set to \"Debian\" or \"Ubuntu\""
     msg2 "This script can only install custom kernels for Ubuntu and Debian derivatives. Exiting..."
     exit 0


### PR DESCRIPTION
I only applied it in version 5.8 so that first you can see if it applies to all, or if my solution is viable.

The problem is that every time it does the verification, it downloads the original configuration from github and does not maintain its own manual configuration that solves the certificate problem in Debian, it does not finish compiling for that reason.

And when you give Install.sh the CONFIG_SYSTEM_TRUSTED_KEYS = "debian / certs / test-signing-certs.pem" is reset, regardless of whether you edited it.