### PR TITLE
Add initial -rc support to the install.sh script.

### DIFF
--- a/linux59-rc-tkg/install.sh
+++ b/linux59-rc-tkg/install.sh
@@ -21,6 +21,8 @@ set -e
 
 _where=`pwd`
 srcdir="$_where"
+# This is an RC, so subver will always be 0
+_kernel_subver=0
 
 source linux*-tkg-config/prepare
 
@@ -100,7 +102,9 @@ if [ "$1" = "install" ] || [ "$1" = "config" ]; then
   if [ -d linux-${_basekernel}-${_sub}.orig ]; then
     rm -rf linux-${_basekernel}-${_sub}.orig
   fi
-
+  
+  msg2 "Building version ${_basekernel}.${_kernel_subver}_${_sub}"
+  
   if [ -d linux-${_basekernel}-${_sub} ]; then
     msg2 "You already have the current -rc .tar.gz downloaded, cleaning up and re-downloading..."
     rm -r $_where/linux-${_basekernel}-${_sub} 
@@ -227,7 +231,7 @@ if [ "$1" = "install" ]; then
 
       read -p "Do you want to install the new Kernel ? y/[n]: " _install
       if [ "$_install" = "y" ] || [ "$_install" = "Y" ] || [ "$_install" = "yes" ] || [ "$_install" = "Yes" ]; then
-        _kernelname=${_basekernel}_${_sub}_$_kernel_flavor
+        _kernelname=${_basekernel}.${_kernel_subver}_${_sub}_$_kernel_flavor
         _headers_rpm="kernel-headers-${_kernelname}*.rpm"
         _kernel_rpm="kernel-${_kernelname}*.rpm"
         _kernel_devel_rpm="kernel-devel-${_kernelname}*.rpm"

--- a/linux59-rc-tkg/install.sh
+++ b/linux59-rc-tkg/install.sh
@@ -116,7 +116,7 @@ if [ "$1" = "install" ] || [ "$1" = "config" ]; then
     fi
 
     rm -r $_where/linux-${_basekernel}-${_sub} 
-    tar xvpf linux-${_basekernel}-${_sub}.tar.gz
+    tar xpf linux-${_basekernel}-${_sub}.tar.gz
     msg2 "Done"
   else
     msg2 "Downloading linux ${_basekernel}-${_sub}"

--- a/linux59-rc-tkg/install.sh
+++ b/linux59-rc-tkg/install.sh
@@ -121,7 +121,7 @@ if [ "$1" = "install" ] || [ "$1" = "config" ]; then
   else
     msg2 "Downloading linux ${_basekernel}-${_sub}"
     wget https://git.kernel.org/torvalds/t/linux-${_basekernel}-${_sub}.tar.gz
-    tar xvpf linux-${_basekernel}-${_sub}.tar.gz
+    tar xpf linux-${_basekernel}-${_sub}.tar.gz
     msg2 "Done"
   fi
   

--- a/linux59-rc-tkg/install.sh
+++ b/linux59-rc-tkg/install.sh
@@ -106,9 +106,16 @@ if [ "$1" = "install" ] || [ "$1" = "config" ]; then
   msg2 "Building version ${_basekernel}.${_kernel_subver}_${_sub}"
   
   if [ -d linux-${_basekernel}-${_sub} ]; then
-    msg2 "You already have the current -rc .tar.gz downloaded, cleaning up and re-downloading..."
+    msg2 "You already have a linux-${_basekernel}-${_sub} folder, cleaning up..."
+    
+    if [ -f linux-${_basekernel}-${_sub}.tar.gz ]; then
+      msg2 "linux-${_basekernel}-${_sub}.tar.gz already exists, using current"
+    else
+      msg2 "linux-${_basekernel}-${_sub}.tar.gz doesn't exist, downloading"
+      wget https://git.kernel.org/torvalds/t/linux-${_basekernel}-${_sub}.tar.gz
+    fi
+
     rm -r $_where/linux-${_basekernel}-${_sub} 
-    wget https://git.kernel.org/torvalds/t/linux-${_basekernel}-${_sub}.tar.gz
     tar xvpf linux-${_basekernel}-${_sub}.tar.gz
     msg2 "Done"
   else

--- a/linux59-rc-tkg/install.sh
+++ b/linux59-rc-tkg/install.sh
@@ -30,7 +30,7 @@ source customization.cfg
 
 if [ "$1" != "install" ] && [ "$1" != "config" ] && [ "$1" != "uninstall-help" ]; then
   msg2 "Argument not recognised, options are:
-        - config : Downloads the ${_basekernel}-${_sub} kernel .tar.gz into the folder linux-${_basekernel}-${_sub}, then applies on it the extra patches and prepares the .config file 
+        - config : Downloads the ${_basekernel}-${_sub} kernel .tar.gz and extracts it into the folder linux-${_basekernel}-${_sub}, then applies on it the extra patches and prepares the .config file 
                    by copying the one from the current linux system in /boot/config-`uname -r` and updates it. 
         - install : [RPM and DEB based distros only], does the config step, proceeds to compile, then prompts to install
         - uninstall-help : [RPM and DEB based distros only], lists the installed kernels in this system, then gives a hint on how to uninstall them manually."
@@ -105,7 +105,7 @@ if [ "$1" = "install" ] || [ "$1" = "config" ]; then
     echo "You already have the current -rc .tar.gz downloaded"
   else
     msg2 "Downloading linux ${_basekernel}-${_sub}"
-    wget https://git.kernel.org/torvalds/t/linux-${_basekernel}-${_sub}.tar.gz
+    wget https://git.kernel.org/torvalds/t/linux--${_sub}.tar.gz
     tar xvpf linux-${_basekernel}-${_sub}.tar.gz
     msg2 "Done"
   fi

--- a/linux59-rc-tkg/install.sh
+++ b/linux59-rc-tkg/install.sh
@@ -102,10 +102,14 @@ if [ "$1" = "install" ] || [ "$1" = "config" ]; then
   fi
 
   if [ -d linux-${_basekernel}-${_sub} ]; then
-    echo "You already have the current -rc .tar.gz downloaded"
+    msg2 "You already have the current -rc .tar.gz downloaded, cleaning up and re-downloading..."
+    rm -r $_where/linux-${_basekernel}-${_sub} 
+    wget https://git.kernel.org/torvalds/t/linux-${_basekernel}-${_sub}.tar.gz
+    tar xvpf linux-${_basekernel}-${_sub}.tar.gz
+    msg2 "Done"
   else
     msg2 "Downloading linux ${_basekernel}-${_sub}"
-    wget https://git.kernel.org/torvalds/t/linux--${_sub}.tar.gz
+    wget https://git.kernel.org/torvalds/t/linux-${_basekernel}-${_sub}.tar.gz
     tar xvpf linux-${_basekernel}-${_sub}.tar.gz
     msg2 "Done"
   fi

--- a/linux59-rc-tkg/install.sh
+++ b/linux59-rc-tkg/install.sh
@@ -227,12 +227,13 @@ if [ "$1" = "install" ]; then
 
       read -p "Do you want to install the new Kernel ? y/[n]: " _install
       if [ "$_install" = "y" ] || [ "$_install" = "Y" ] || [ "$_install" = "yes" ] || [ "$_install" = "Yes" ]; then
-        _kernelname=${_basekernel}-${_sub}_$_kernel_flavor
+      	# I told rpm-pkg to use -$sub_kernel_flavor but it instead uses _$sub_$kernel_flavor
+      	# am I missing something? lol
+        _kernelname=${_basekernel}_${_sub}_$_kernel_flavor
         _headers_rpm="kernel-headers-${_kernelname}*.rpm"
         _kernel_rpm="kernel-${_kernelname}*.rpm"
         _kernel_devel_rpm="kernel-devel-${_kernelname}*.rpm"
         
-
         cd RPMS
         if [ "$_distro" = "Fedora" ]; then
           sudo dnf install $_headers_rpm $_kernel_rpm $_kernel_devel_rpm

--- a/linux59-rc-tkg/install.sh
+++ b/linux59-rc-tkg/install.sh
@@ -175,7 +175,8 @@ if [ "$1" = "install" ]; then
 
   if [ "$_distro" = "Ubuntu" ]  || [ "$_distro" = "Debian" ]; then
 
-    if make -j ${_thread_num} deb-pkg LOCALVERSION=-${_kernel_flavor}; then
+    # Doesn't seem to include -rc(x) by default, so will have to add it to LOCALVERSION
+    if make -j ${_thread_num} deb-pkg LOCALVERSION=-${_sub}-${_kernel_flavor}; then
       msg2 "Building successfully finished!"
 
       cd "$_where"
@@ -205,7 +206,8 @@ if [ "$1" = "install" ]; then
     # Se we can actually refer properly to the rpm files.
     _kernel_flavor=${_kernel_flavor//-/_}
 
-    if make -j ${_thread_num} rpm-pkg EXTRAVERSION="_${_kernel_flavor}"; then
+    # Doesn't seem to include -rc(x) by default, so will have to add it to EXTRAVERSION
+    if make -j ${_thread_num} rpm-pkg EXTRAVERSION="-${_sub}_${_kernel_flavor}"; then
       msg2 "Building successfully finished!"
 
       cd "$_where"
@@ -221,7 +223,6 @@ if [ "$1" = "install" ]; then
 
       read -p "Do you want to install the new Kernel ? y/[n]: " _install
       if [ "$_install" = "y" ] || [ "$_install" = "Y" ] || [ "$_install" = "yes" ] || [ "$_install" = "Yes" ]; then
-        
         _kernelname=${_basekernel}-${_sub}_$_kernel_flavor
         _headers_rpm="kernel-headers-${_kernelname}*.rpm"
         _kernel_rpm="kernel-${_kernelname}*.rpm"

--- a/linux59-rc-tkg/install.sh
+++ b/linux59-rc-tkg/install.sh
@@ -211,7 +211,7 @@ if [ "$1" = "install" ]; then
     _kernel_flavor=${_kernel_flavor//-/_}
 
     # Doesn't seem to include -rc(x) by default, so will have to add it to EXTRAVERSION
-    if make -j ${_thread_num} rpm-pkg EXTRAVERSION="-${_sub}_${_kernel_flavor}"; then
+    if make -j ${_thread_num} rpm-pkg EXTRAVERSION="_${_sub}_${_kernel_flavor}"; then
       msg2 "Building successfully finished!"
 
       cd "$_where"
@@ -227,8 +227,6 @@ if [ "$1" = "install" ]; then
 
       read -p "Do you want to install the new Kernel ? y/[n]: " _install
       if [ "$_install" = "y" ] || [ "$_install" = "Y" ] || [ "$_install" = "yes" ] || [ "$_install" = "Yes" ]; then
-      	# I told rpm-pkg to use -$sub_kernel_flavor but it instead uses _$sub_$kernel_flavor
-      	# am I missing something? lol
         _kernelname=${_basekernel}_${_sub}_$_kernel_flavor
         _headers_rpm="kernel-headers-${_kernelname}*.rpm"
         _kernel_rpm="kernel-${_kernelname}*.rpm"

--- a/linux59-rc-tkg/install.sh
+++ b/linux59-rc-tkg/install.sh
@@ -191,7 +191,7 @@ if [ "$1" = "install" ]; then
   if [ "$_distro" = "Ubuntu" ]  || [ "$_distro" = "Debian" ]; then
 
     # Doesn't seem to include -rc(x) by default, so will have to add it to LOCALVERSION
-    if make -j ${_thread_num} deb-pkg LOCALVERSION=-${_sub}-${_kernel_flavor}; then
+    if make -j ${_thread_num} deb-pkg LOCALVERSION=-${_kernel_flavor}; then
       msg2 "Building successfully finished!"
 
       cd "$_where"
@@ -205,7 +205,7 @@ if [ "$1" = "install" ]; then
       read -p "Do you want to install the new Kernel ? y/[n]: " _install
       if [[ $_install =~ [yY] ]] || [ $_install = "yes" ] || [ $_install = "Yes" ]; then
         cd "$_where"
-        _kernelname=${_basekernel}-${_sub}-$_kernel_flavor
+        _kernelname=${_basekernel}.0-${_sub}-$_kernel_flavor
         _headers_deb="linux-headers-${_kernelname}*.deb"
         _image_deb="linux-image-${_kernelname}_*.deb"
         _kernel_devel_deb="linux-libc-dev_${_kernelname}*.deb"


### PR DESCRIPTION
Fixes #58 

Marginally tested. Builds, creates the RPMs and works fine when building.
Also installs the kernel fine.

Please someone test in Debian, don't have any debian-based machine to test :(
Confirmed to work in Fedora.

Fully reusable for future -RCs.