### PR TITLE
Fix cleanup step on non-arch distros

### DIFF
--- a/linux57-tkg/linux57-tkg-config/prepare
+++ b/linux57-tkg/linux57-tkg-config/prepare
@@ -917,60 +917,60 @@ exit_cleanup() {
     rm -f "$_where"/"$_p"
   done
 
-  if [ "$_NUKR" = "true" ] && [ "$_where" != "$srcdir" ]; then
-    rm -rf "$_where"/src/*
-    # Double tap
-    rm -rf "$srcdir"/linux-*
-    rm -rf "$srcdir"/*.xz
-    rm -rf "$srcdir"/*.patch
-    rm -rf "$srcdir"/*-profile.cfg
-    rm -f "$srcdir"/config.x86_64
-    rm -f "$srcdir"/customization.cfg
-  else
-    # Meh
-    rm -rf "$srcdir"/linux-${_basekernel}/Documentation/filesystems/aufs/*
-    rm -f "$srcdir"/linux-${_basekernel}/Documentation/ABI/testing/*-aufs
-    rm -rf "$srcdir"/linux-${_basekernel}/fs/aufs/*
-    rm -f "$srcdir"/linux-${_basekernel}/include/uapi/linux/aufs*
-
-    rm -f "$srcdir"/linux-${_basekernel}/mm/prfile.c
-
-    rm -f "$srcdir"/linux-${_basekernel}/block/bfq*
-
-    rm -rf "$srcdir"/linux-${_basekernel}/drivers/scsi/vhba/*
-
-    rm -rf "$srcdir"/linux-${_basekernel}/fs/exfat/*
-    rm -f "$srcdir"/linux-${_basekernel}/include/trace/events/fs.h
-
-    rm -f "$srcdir"/linux-${_basekernel}/Documentation/scheduler/sched-PDS-mq.txt
-    rm -f "$srcdir"/linux-${_basekernel}/include/linux/skip_list.h
-    rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/pds.c
-    rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/pds_sched.h
-
-    rm -f "$srcdir"/linux-${_basekernel}/Documentation/scheduler/sched-BMQ.txt
-    rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/alt_core.c
-    rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/sched/alt_debug.c
-    rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/alt_sched.h
-
-    rm -f "$srcdir"/linux-${_basekernel}/Documentation/scheduler/sched-BFS.txt
-    rm -f "$srcdir"/linux-${_basekernel}/Documentation/scheduler/sched-MuQSS.txt
-    rm -rf "$srcdir"/linux-${_basekernel}/arch/blackfin/*
-    rm -f "$srcdir"/linux-${_basekernel}/arch/powerpc/configs/c2k_defconfig
-    rm -f "$srcdir"/linux-${_basekernel}/arch/score/configs/spct6600_defconfig
-    rm -f "$srcdir"/linux-${_basekernel}/arch/tile/configs/tilegx_defconfig
-    rm -f "$srcdir"/linux-${_basekernel}/arch/tile/configs/tilepro_defconfig
-    rm -f "$srcdir"/linux-${_basekernel}/drivers/staging/lustre/lnet/lnet/lib-eq.c
-    rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/MuQSS*
-    rm -f "$srcdir"/linux-${_basekernel}/kernel/skip_list.c
-
-    rm -f "$srcdir"/linux-${_basekernel}/Documentation/vm/uksm.txt
-    rm -f "$srcdir"/linux-${_basekernel}/include/linux/sradix-tree.h
-    rm -f "$srcdir"/linux-${_basekernel}/include/linux/uksm.h
-    rm -f "$srcdir"/linux-${_basekernel}/lib/sradix-tree.c
-    rm -f "$srcdir"/linux-${_basekernel}/mm/uksm.c
-  fi
-
   if [ "${_distro}" = "Arch" ]; then
+    if [ "$_NUKR" = "true" ] && [ "$_where" != "$srcdir" ]; then
+      rm -rf "$_where"/src/*
+      # Double tap
+      rm -rf "$srcdir"/linux-*
+      rm -rf "$srcdir"/*.xz
+      rm -rf "$srcdir"/*.patch
+      rm -rf "$srcdir"/*-profile.cfg
+      rm -f "$srcdir"/config.x86_64
+      rm -f "$srcdir"/customization.cfg
+    else
+      # Meh
+      rm -rf "$srcdir"/linux-${_basekernel}/Documentation/filesystems/aufs/*
+      rm -f "$srcdir"/linux-${_basekernel}/Documentation/ABI/testing/*-aufs
+      rm -rf "$srcdir"/linux-${_basekernel}/fs/aufs/*
+      rm -f "$srcdir"/linux-${_basekernel}/include/uapi/linux/aufs*
+
+      rm -f "$srcdir"/linux-${_basekernel}/mm/prfile.c
+
+      rm -f "$srcdir"/linux-${_basekernel}/block/bfq*
+
+      rm -rf "$srcdir"/linux-${_basekernel}/drivers/scsi/vhba/*
+
+      rm -rf "$srcdir"/linux-${_basekernel}/fs/exfat/*
+      rm -f "$srcdir"/linux-${_basekernel}/include/trace/events/fs.h
+
+      rm -f "$srcdir"/linux-${_basekernel}/Documentation/scheduler/sched-PDS-mq.txt
+      rm -f "$srcdir"/linux-${_basekernel}/include/linux/skip_list.h
+      rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/pds.c
+      rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/pds_sched.h
+
+      rm -f "$srcdir"/linux-${_basekernel}/Documentation/scheduler/sched-BMQ.txt
+      rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/alt_core.c
+      rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/sched/alt_debug.c
+      rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/alt_sched.h
+
+      rm -f "$srcdir"/linux-${_basekernel}/Documentation/scheduler/sched-BFS.txt
+      rm -f "$srcdir"/linux-${_basekernel}/Documentation/scheduler/sched-MuQSS.txt
+      rm -rf "$srcdir"/linux-${_basekernel}/arch/blackfin/*
+      rm -f "$srcdir"/linux-${_basekernel}/arch/powerpc/configs/c2k_defconfig
+      rm -f "$srcdir"/linux-${_basekernel}/arch/score/configs/spct6600_defconfig
+      rm -f "$srcdir"/linux-${_basekernel}/arch/tile/configs/tilegx_defconfig
+      rm -f "$srcdir"/linux-${_basekernel}/arch/tile/configs/tilepro_defconfig
+      rm -f "$srcdir"/linux-${_basekernel}/drivers/staging/lustre/lnet/lnet/lib-eq.c
+      rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/MuQSS*
+      rm -f "$srcdir"/linux-${_basekernel}/kernel/skip_list.c
+
+      rm -f "$srcdir"/linux-${_basekernel}/Documentation/vm/uksm.txt
+      rm -f "$srcdir"/linux-${_basekernel}/include/linux/sradix-tree.h
+      rm -f "$srcdir"/linux-${_basekernel}/include/linux/uksm.h
+      rm -f "$srcdir"/linux-${_basekernel}/lib/sradix-tree.c
+      rm -f "$srcdir"/linux-${_basekernel}/mm/uksm.c
+    fi
+
     remove_deps
   fi
 

--- a/linux58-tkg/linux58-tkg-config/prepare
+++ b/linux58-tkg/linux58-tkg-config/prepare
@@ -944,60 +944,60 @@ exit_cleanup() {
     rm -f "$_where"/"$_p"
   done
 
-  if [ "$_NUKR" = "true" ] && [ "$_where" != "$srcdir" ]; then
-    rm -rf "$_where"/src/*
-    # Double tap
-    rm -rf "$srcdir"/linux-*
-    rm -rf "$srcdir"/*.xz
-    rm -rf "$srcdir"/*.patch
-    rm -rf "$srcdir"/*-profile.cfg
-    rm -f "$srcdir"/config.x86_64
-    rm -f "$srcdir"/customization.cfg
-  else
-    # Meh
-    rm -rf "$srcdir"/linux-${_basekernel}/Documentation/filesystems/aufs/*
-    rm -f "$srcdir"/linux-${_basekernel}/Documentation/ABI/testing/*-aufs
-    rm -rf "$srcdir"/linux-${_basekernel}/fs/aufs/*
-    rm -f "$srcdir"/linux-${_basekernel}/include/uapi/linux/aufs*
-
-    rm -f "$srcdir"/linux-${_basekernel}/mm/prfile.c
-
-    rm -f "$srcdir"/linux-${_basekernel}/block/bfq*
-
-    rm -rf "$srcdir"/linux-${_basekernel}/drivers/scsi/vhba/*
-
-    rm -rf "$srcdir"/linux-${_basekernel}/fs/exfat/*
-    rm -f "$srcdir"/linux-${_basekernel}/include/trace/events/fs.h
-
-    rm -f "$srcdir"/linux-${_basekernel}/Documentation/scheduler/sched-PDS-mq.txt
-    rm -f "$srcdir"/linux-${_basekernel}/include/linux/skip_list.h
-    rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/pds.c
-    rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/pds_sched.h
-
-    rm -f "$srcdir"/linux-${_basekernel}/Documentation/scheduler/sched-BMQ.txt
-    rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/alt_core.c
-    rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/sched/alt_debug.c
-    rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/alt_sched.h
-
-    rm -f "$srcdir"/linux-${_basekernel}/Documentation/scheduler/sched-BFS.txt
-    rm -f "$srcdir"/linux-${_basekernel}/Documentation/scheduler/sched-MuQSS.txt
-    rm -rf "$srcdir"/linux-${_basekernel}/arch/blackfin/*
-    rm -f "$srcdir"/linux-${_basekernel}/arch/powerpc/configs/c2k_defconfig
-    rm -f "$srcdir"/linux-${_basekernel}/arch/score/configs/spct6600_defconfig
-    rm -f "$srcdir"/linux-${_basekernel}/arch/tile/configs/tilegx_defconfig
-    rm -f "$srcdir"/linux-${_basekernel}/arch/tile/configs/tilepro_defconfig
-    rm -f "$srcdir"/linux-${_basekernel}/drivers/staging/lustre/lnet/lnet/lib-eq.c
-    rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/MuQSS*
-    rm -f "$srcdir"/linux-${_basekernel}/kernel/skip_list.c
-
-    rm -f "$srcdir"/linux-${_basekernel}/Documentation/vm/uksm.txt
-    rm -f "$srcdir"/linux-${_basekernel}/include/linux/sradix-tree.h
-    rm -f "$srcdir"/linux-${_basekernel}/include/linux/uksm.h
-    rm -f "$srcdir"/linux-${_basekernel}/lib/sradix-tree.c
-    rm -f "$srcdir"/linux-${_basekernel}/mm/uksm.c
-  fi
-
   if [ "${_distro}" = "Arch" ]; then
+    if [ "$_NUKR" = "true" ] && [ "$_where" != "$srcdir" ]; then
+      rm -rf "$_where"/src/*
+      # Double tap
+      rm -rf "$srcdir"/linux-*
+      rm -rf "$srcdir"/*.xz
+      rm -rf "$srcdir"/*.patch
+      rm -rf "$srcdir"/*-profile.cfg
+      rm -f "$srcdir"/config.x86_64
+      rm -f "$srcdir"/customization.cfg
+    else
+      # Meh
+      rm -rf "$srcdir"/linux-${_basekernel}/Documentation/filesystems/aufs/*
+      rm -f "$srcdir"/linux-${_basekernel}/Documentation/ABI/testing/*-aufs
+      rm -rf "$srcdir"/linux-${_basekernel}/fs/aufs/*
+      rm -f "$srcdir"/linux-${_basekernel}/include/uapi/linux/aufs*
+
+      rm -f "$srcdir"/linux-${_basekernel}/mm/prfile.c
+
+      rm -f "$srcdir"/linux-${_basekernel}/block/bfq*
+
+      rm -rf "$srcdir"/linux-${_basekernel}/drivers/scsi/vhba/*
+
+      rm -rf "$srcdir"/linux-${_basekernel}/fs/exfat/*
+      rm -f "$srcdir"/linux-${_basekernel}/include/trace/events/fs.h
+
+      rm -f "$srcdir"/linux-${_basekernel}/Documentation/scheduler/sched-PDS-mq.txt
+      rm -f "$srcdir"/linux-${_basekernel}/include/linux/skip_list.h
+      rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/pds.c
+      rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/pds_sched.h
+
+      rm -f "$srcdir"/linux-${_basekernel}/Documentation/scheduler/sched-BMQ.txt
+      rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/alt_core.c
+      rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/sched/alt_debug.c
+      rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/alt_sched.h
+
+      rm -f "$srcdir"/linux-${_basekernel}/Documentation/scheduler/sched-BFS.txt
+      rm -f "$srcdir"/linux-${_basekernel}/Documentation/scheduler/sched-MuQSS.txt
+      rm -rf "$srcdir"/linux-${_basekernel}/arch/blackfin/*
+      rm -f "$srcdir"/linux-${_basekernel}/arch/powerpc/configs/c2k_defconfig
+      rm -f "$srcdir"/linux-${_basekernel}/arch/score/configs/spct6600_defconfig
+      rm -f "$srcdir"/linux-${_basekernel}/arch/tile/configs/tilegx_defconfig
+      rm -f "$srcdir"/linux-${_basekernel}/arch/tile/configs/tilepro_defconfig
+      rm -f "$srcdir"/linux-${_basekernel}/drivers/staging/lustre/lnet/lnet/lib-eq.c
+      rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/MuQSS*
+      rm -f "$srcdir"/linux-${_basekernel}/kernel/skip_list.c
+
+      rm -f "$srcdir"/linux-${_basekernel}/Documentation/vm/uksm.txt
+      rm -f "$srcdir"/linux-${_basekernel}/include/linux/sradix-tree.h
+      rm -f "$srcdir"/linux-${_basekernel}/include/linux/uksm.h
+      rm -f "$srcdir"/linux-${_basekernel}/lib/sradix-tree.c
+      rm -f "$srcdir"/linux-${_basekernel}/mm/uksm.c
+    fi
+      
     remove_deps
   fi
 

--- a/linux59-rc-tkg/linux59-tkg-config/prepare
+++ b/linux59-rc-tkg/linux59-tkg-config/prepare
@@ -912,60 +912,60 @@ exit_cleanup() {
     rm -f "$_where"/"$_p"
   done
 
-  if [ "$_NUKR" = "true" ] && [ "$_where" != "$srcdir" ]; then
-    rm -rf "$_where"/src/*
-    # Double tap
-    rm -rf "$srcdir"/linux-*
-    rm -rf "$srcdir"/*.xz
-    rm -rf "$srcdir"/*.patch
-    rm -rf "$srcdir"/*-profile.cfg
-    rm -f "$srcdir"/config.x86_64
-    rm -f "$srcdir"/customization.cfg
-  else
-    # Meh
-    rm -rf "$srcdir"/linux-${_basekernel}/Documentation/filesystems/aufs/*
-    rm -f "$srcdir"/linux-${_basekernel}/Documentation/ABI/testing/*-aufs
-    rm -rf "$srcdir"/linux-${_basekernel}/fs/aufs/*
-    rm -f "$srcdir"/linux-${_basekernel}/include/uapi/linux/aufs*
-
-    rm -f "$srcdir"/linux-${_basekernel}/mm/prfile.c
-
-    rm -f "$srcdir"/linux-${_basekernel}/block/bfq*
-
-    rm -rf "$srcdir"/linux-${_basekernel}/drivers/scsi/vhba/*
-
-    rm -rf "$srcdir"/linux-${_basekernel}/fs/exfat/*
-    rm -f "$srcdir"/linux-${_basekernel}/include/trace/events/fs.h
-
-    rm -f "$srcdir"/linux-${_basekernel}/Documentation/scheduler/sched-PDS-mq.txt
-    rm -f "$srcdir"/linux-${_basekernel}/include/linux/skip_list.h
-    rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/pds.c
-    rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/pds_sched.h
-
-    rm -f "$srcdir"/linux-${_basekernel}/Documentation/scheduler/sched-BMQ.txt
-    rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/alt_core.c
-    rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/sched/alt_debug.c
-    rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/alt_sched.h
-
-    rm -f "$srcdir"/linux-${_basekernel}/Documentation/scheduler/sched-BFS.txt
-    rm -f "$srcdir"/linux-${_basekernel}/Documentation/scheduler/sched-MuQSS.txt
-    rm -rf "$srcdir"/linux-${_basekernel}/arch/blackfin/*
-    rm -f "$srcdir"/linux-${_basekernel}/arch/powerpc/configs/c2k_defconfig
-    rm -f "$srcdir"/linux-${_basekernel}/arch/score/configs/spct6600_defconfig
-    rm -f "$srcdir"/linux-${_basekernel}/arch/tile/configs/tilegx_defconfig
-    rm -f "$srcdir"/linux-${_basekernel}/arch/tile/configs/tilepro_defconfig
-    rm -f "$srcdir"/linux-${_basekernel}/drivers/staging/lustre/lnet/lnet/lib-eq.c
-    rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/MuQSS*
-    rm -f "$srcdir"/linux-${_basekernel}/kernel/skip_list.c
-
-    rm -f "$srcdir"/linux-${_basekernel}/Documentation/vm/uksm.txt
-    rm -f "$srcdir"/linux-${_basekernel}/include/linux/sradix-tree.h
-    rm -f "$srcdir"/linux-${_basekernel}/include/linux/uksm.h
-    rm -f "$srcdir"/linux-${_basekernel}/lib/sradix-tree.c
-    rm -f "$srcdir"/linux-${_basekernel}/mm/uksm.c
-  fi
-
   if [ "${_distro}" = "Arch" ]; then
+    if [ "$_NUKR" = "true" ] && [ "$_where" != "$srcdir" ]; then
+      rm -rf "$_where"/src/*
+      # Double tap
+      rm -rf "$srcdir"/linux-*
+      rm -rf "$srcdir"/*.xz
+      rm -rf "$srcdir"/*.patch
+      rm -rf "$srcdir"/*-profile.cfg
+      rm -f "$srcdir"/config.x86_64
+      rm -f "$srcdir"/customization.cfg
+    else
+      # Meh
+      rm -rf "$srcdir"/linux-${_basekernel}/Documentation/filesystems/aufs/*
+      rm -f "$srcdir"/linux-${_basekernel}/Documentation/ABI/testing/*-aufs
+      rm -rf "$srcdir"/linux-${_basekernel}/fs/aufs/*
+      rm -f "$srcdir"/linux-${_basekernel}/include/uapi/linux/aufs*
+
+      rm -f "$srcdir"/linux-${_basekernel}/mm/prfile.c
+
+      rm -f "$srcdir"/linux-${_basekernel}/block/bfq*
+
+      rm -rf "$srcdir"/linux-${_basekernel}/drivers/scsi/vhba/*
+
+      rm -rf "$srcdir"/linux-${_basekernel}/fs/exfat/*
+      rm -f "$srcdir"/linux-${_basekernel}/include/trace/events/fs.h
+
+      rm -f "$srcdir"/linux-${_basekernel}/Documentation/scheduler/sched-PDS-mq.txt
+      rm -f "$srcdir"/linux-${_basekernel}/include/linux/skip_list.h
+      rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/pds.c
+      rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/pds_sched.h
+
+      rm -f "$srcdir"/linux-${_basekernel}/Documentation/scheduler/sched-BMQ.txt
+      rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/alt_core.c
+      rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/sched/alt_debug.c
+      rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/alt_sched.h
+
+      rm -f "$srcdir"/linux-${_basekernel}/Documentation/scheduler/sched-BFS.txt
+      rm -f "$srcdir"/linux-${_basekernel}/Documentation/scheduler/sched-MuQSS.txt
+      rm -rf "$srcdir"/linux-${_basekernel}/arch/blackfin/*
+      rm -f "$srcdir"/linux-${_basekernel}/arch/powerpc/configs/c2k_defconfig
+      rm -f "$srcdir"/linux-${_basekernel}/arch/score/configs/spct6600_defconfig
+      rm -f "$srcdir"/linux-${_basekernel}/arch/tile/configs/tilegx_defconfig
+      rm -f "$srcdir"/linux-${_basekernel}/arch/tile/configs/tilepro_defconfig
+      rm -f "$srcdir"/linux-${_basekernel}/drivers/staging/lustre/lnet/lnet/lib-eq.c
+      rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/MuQSS*
+      rm -f "$srcdir"/linux-${_basekernel}/kernel/skip_list.c
+
+      rm -f "$srcdir"/linux-${_basekernel}/Documentation/vm/uksm.txt
+      rm -f "$srcdir"/linux-${_basekernel}/include/linux/sradix-tree.h
+      rm -f "$srcdir"/linux-${_basekernel}/include/linux/uksm.h
+      rm -f "$srcdir"/linux-${_basekernel}/lib/sradix-tree.c
+      rm -f "$srcdir"/linux-${_basekernel}/mm/uksm.c
+    fi
+
     remove_deps
   fi
 


### PR DESCRIPTION
This PR fixes #64 

The `install.sh` script cleans up by itself what's in the linux git folder and does not need cleaning up. And it was affecting the `config` feature it offered of patching&configuring the git folder and leaving it in that state so the user can compile it in the way he likes.