### PR TITLE
Fix build fail certificate UEFI on Debian 5.7/5.8/5.9rc

### DIFF
--- a/linux57-tkg/install.sh
+++ b/linux57-tkg/install.sh
@@ -140,6 +140,7 @@ if [ "$1" = "install" ] || [ "$1" = "config" ]; then
   cp /boot/config-`uname -r` .config
   if [ "$_distro" = "Debian" ]; then #Help Debian cert problem.
     sed -i -e 's#CONFIG_SYSTEM_TRUSTED_KEYS="debian/certs/test-signing-certs.pem"#CONFIG_SYSTEM_TRUSTED_KEYS=""#g' .config
+    sed -i -e 's#CONFIG_SYSTEM_TRUSTED_KEYS="debian/certs/debian-uefi-certs.pem"#CONFIG_SYSTEM_TRUSTED_KEYS=""#g' .config
   fi
   yes '' | make oldconfig
   msg2 "Done"

--- a/linux58-tkg/install.sh
+++ b/linux58-tkg/install.sh
@@ -140,6 +140,7 @@ if [ "$1" = "install" ] || [ "$1" = "config" ]; then
   cp /boot/config-`uname -r` .config
   if [ "$_distro" = "Debian" ]; then #Help Debian cert problem.
     sed -i -e 's#CONFIG_SYSTEM_TRUSTED_KEYS="debian/certs/test-signing-certs.pem"#CONFIG_SYSTEM_TRUSTED_KEYS=""#g' .config
+    sed -i -e 's#CONFIG_SYSTEM_TRUSTED_KEYS="debian/certs/debian-uefi-certs.pem"#CONFIG_SYSTEM_TRUSTED_KEYS=""#g' .config
   fi
   yes '' | make oldconfig
   msg2 "Done"

--- a/linux59-rc-tkg/install.sh
+++ b/linux59-rc-tkg/install.sh
@@ -139,6 +139,7 @@ if [ "$1" = "install" ] || [ "$1" = "config" ]; then
   cp /boot/config-`uname -r` .config
   if [ "$_distro" = "Debian" ]; then #Help Debian cert problem.
     sed -i -e 's#CONFIG_SYSTEM_TRUSTED_KEYS="debian/certs/test-signing-certs.pem"#CONFIG_SYSTEM_TRUSTED_KEYS=""#g' .config
+    sed -i -e 's#CONFIG_SYSTEM_TRUSTED_KEYS="debian/certs/debian-uefi-certs.pem"#CONFIG_SYSTEM_TRUSTED_KEYS=""#g' .config
   fi
   yes '' | make oldconfig
   msg2 "Done"


### PR DESCRIPTION
Reason that the compilation fails due to the need for this certificate, it is not necessary and only causes problems