### PR TITLE
linux58-tkg: Remove "include/linux/compiler*.h: define asm_volatile_g…

### DIFF
--- a/linux58-tkg/linux58-tkg-patches/0003-glitched-base.patch
+++ b/linux58-tkg/linux58-tkg-patches/0003-glitched-base.patch
@@ -282,34 +282,6 @@ index 80dad301361d..42b7fa7d01f8 100644
  	default "veno" if DEFAULT_VENO
  	default "reno" if DEFAULT_RENO
 
-From: Nick Desaulniers <ndesaulniers@google.com>
-Date: Mon, 24 Dec 2018 13:37:41 +0200
-Subject: include/linux/compiler*.h: define asm_volatile_goto
-
-asm_volatile_goto should also be defined for other compilers that
-support asm goto.
-
-Fixes commit 815f0dd ("include/linux/compiler*.h: make compiler-*.h
-mutually exclusive").
-
-Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>
-Signed-off-by: Miguel Ojeda <miguel.ojeda.sandonis@gmail.com>
-
-diff --git a/include/linux/compiler_types.h b/include/linux/compiler_types.h
-index ba814f1..e77eeb0 100644
---- a/include/linux/compiler_types.h
-+++ b/include/linux/compiler_types.h
-@@ -188,6 +188,10 @@ struct ftrace_likely_data {
- #define asm_volatile_goto(x...) asm goto(x)
- #endif
- 
-+#ifndef asm_volatile_goto
-+#define asm_volatile_goto(x...) asm goto(x)
-+#endif
-+
- /* Are two types/vars the same type (ignoring qualifiers)? */
- #define __same_type(a, b) __builtin_types_compatible_p(typeof(a), typeof(b))
- 
 From: Andy Lavr <andy.lavr@gmail.com>
 Date: Mon, 24 Dec 2018 14:57:47 +0200
 Subject: avl: Use [defer+madvise] as default khugepaged defrag strategy


### PR DESCRIPTION
…oto"

It was merged upstream in commit 8bd66d147c88bd441178c7b4c774ae5a185f19b8
in Linux v5.0, but was never removed from glitched-base. Applying it just
just adds a duplicate ifndef-define-endif block that has no effect.

Signed-off-by: Juuso Alasuutari <juuso.alasuutari@gmail.com>