### PR TITLE
linux-tkg: cosmetics in localversion if using llvm

### DIFF
--- a/linux-tkg/linux-tkg-config/prepare
+++ b/linux-tkg/linux-tkg-config/prepare
@@ -269,7 +269,7 @@ _tkg_srcprep() {
   if [ "${_distro}" = "Arch" ]; then
     msg2 "Setting version..."
     scripts/setlocalversion --save-scmversion
-    echo "-$pkgrel-tkg-${_cpusched}-${_compiler_name}" > localversion.10-pkgrel
+    echo "-$pkgrel-tkg-${_cpusched}${_compiler_name}" > localversion.10-pkgrel
     echo "" > localversion.20-pkgname
 
     # add upstream patch


### PR DESCRIPTION
There is one additional "-" which shouldn't be here.