### PR TITLE
Add patch for Bug 209745, FS#68346

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -259,6 +259,7 @@ case $_basever in
         	0011-ZFS-fix.patch
 	        #0012-linux-hardened.patch
 		0012-misc-additions.patch
+		0014-5.9-intel-bluetooth-fix.patch
 	)
 	sha256sums=('3239a4ee1250bf2048be988cc8cb46c487b2c8a0de5b1b032d38394d5c6b1a06'
             '7edb7b9d06b02f9b88d868c74ab618baf899c94edb19a73291f640dbea55c312'
@@ -281,7 +282,8 @@ case $_basever in
             'a557b342111849a5f920bbe1c129f3ff1fc1eff62c6bd6685e0972fc88e39911'
             'a5149d7220457d30e03e6999f35a050bce46acafc6230bfe6b4d4994c523516d'
             '49262ce4a8089fa70275aad742fc914baa28d9c384f710c9a62f64796d13e104'
-            '433b919e6a0be26784fb4304c43b1811a28f12ad3de9e26c0af827f64c0c316e')
+            '433b919e6a0be26784fb4304c43b1811a28f12ad3de9e26c0af827f64c0c316e'
+            '04e986afe1d35041271ab02d6d129695097e29b1a452fe159b183f155c844268')
 	;;
 	510)
 	opt_ver="5.8%2B"

--- a/linux-tkg-patches/5.9/0014-5.9-intel-bluetooth-fix.patch
+++ b/linux-tkg-patches/5.9/0014-5.9-intel-bluetooth-fix.patch
@@ -1,0 +1,61 @@
+From: Sathish Narasimman <nsathish41@gmail.com>
+Subject: [PATCH] Bluetooth: Fix: LL PRivacy BLE device fails to connect
+Date: Thu, 22 Oct 2020 13:53:04 +0530
+
+When adding device to white list the device is added to resolving list
+also it has to be added only when HCI_ENABLE_LL_PRIVACY flag is set.
+HCI_ENABLE_LL_PRIVACY flag has to be tested before adding/deleting devices
+to resolving list. use_ll_privacy macro is used only to check if controller
+supports LL_Privacy.
+
+https://bugzilla.kernel.org/show_bug.cgi?id=209745
+
+Signed-off-by: Sathish Narasimman <sathish.narasimman@intel.com>
+---
+ net/bluetooth/hci_request.c | 12 ++++++++----
+ 1 file changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/net/bluetooth/hci_request.c b/net/bluetooth/hci_request.c
+index 6f12bab4d2fa..610ed0817bd7 100644
+--- a/net/bluetooth/hci_request.c
++++ b/net/bluetooth/hci_request.c
+@@ -698,7 +698,8 @@ static void del_from_white_list(struct hci_request *req, bdaddr_t *bdaddr,
+ 		   cp.bdaddr_type);
+ 	hci_req_add(req, HCI_OP_LE_DEL_FROM_WHITE_LIST, sizeof(cp), &cp);
+ 
+-	if (use_ll_privacy(req->hdev)) {
++	if (use_ll_privacy(req->hdev) &&
++	    hci_dev_test_flag(req->hdev, HCI_ENABLE_LL_PRIVACY)) {
+ 		struct smp_irk *irk;
+ 
+ 		irk = hci_find_irk_by_addr(req->hdev, bdaddr, bdaddr_type);
+@@ -732,7 +733,8 @@ static int add_to_white_list(struct hci_request *req,
+ 		return -1;
+ 
+ 	/* White list can not be used with RPAs */
+-	if (!allow_rpa && !use_ll_privacy(hdev) &&
++	if (!allow_rpa &&
++	    !hci_dev_test_flag(hdev, HCI_ENABLE_LL_PRIVACY) &&
+ 	    hci_find_irk_by_addr(hdev, &params->addr, params->addr_type)) {
+ 		return -1;
+ 	}
+@@ -750,7 +752,8 @@ static int add_to_white_list(struct hci_request *req,
+ 		   cp.bdaddr_type);
+ 	hci_req_add(req, HCI_OP_LE_ADD_TO_WHITE_LIST, sizeof(cp), &cp);
+ 
+-	if (use_ll_privacy(hdev)) {
++	if (use_ll_privacy(hdev) &&
++	    hci_dev_test_flag(hdev, HCI_ENABLE_LL_PRIVACY)) {
+ 		struct smp_irk *irk;
+ 
+ 		irk = hci_find_irk_by_addr(hdev, &params->addr,
+@@ -812,7 +815,8 @@ static u8 update_white_list(struct hci_request *req)
+ 		}
+ 
+ 		/* White list can not be used with RPAs */
+-		if (!allow_rpa && !use_ll_privacy(hdev) &&
++		if (!allow_rpa &&
++		    !hci_dev_test_flag(hdev, HCI_ENABLE_LL_PRIVACY) &&
+ 		    hci_find_irk_by_addr(hdev, &b->bdaddr, b->bdaddr_type)) {
+ 			return 0x00;
+ 		}


### PR DESCRIPTION
This adds a patch for a usability-crippling Bluetooth issue which is affecting Intel Bluetooth adapters since 5.9.0.

See:
* https://bugzilla.kernel.org/show_bug.cgi?id=209745
* https://bugs.archlinux.org/task/68346
* https://bbs.archlinux.org/viewtopic.php?pid=1932543
