### PR TITLE
llvm: Fix kcsan prompt showing since we don't want kcsan

### DIFF
--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -478,18 +478,19 @@ _tkg_srcprep() {
 	    || { [ "$_distro" = "Void" ] && xbps-query -s ccache > /dev/null; } ; then
       sed -i -e 's/CONFIG_GCC_PLUGINS=y/# CONFIG_GCC_PLUGINS is not set/' ./.config
     fi
-    # Void uses LibreSSL
-    if [ "$_distro" = "Void" ]; then
-      sed -i -e 's/CONFIG_MODULE_SIG_SHA512=y/# CONFIG_MODULE_SIG_SHA512 is not set/' ./.config
-      sed -i -e 's/# CONFIG_MODULE_SIG_SHA1 is not set/CONFIG_MODULE_SIG_SHA1=y/' ./.config
-      sed -i -e 's/CONFIG_MODULE_SIG_HASH="sha512"/CONFIG_MODULE_SIG_HASH="sha1"/' ./.config
-    fi
+  fi
+  # Void uses LibreSSL
+  if [ "$_distro" = "Void" ]; then
+    sed -i -e 's/CONFIG_MODULE_SIG_SHA512=y/# CONFIG_MODULE_SIG_SHA512 is not set/' ./.config
+    sed -i -e 's/# CONFIG_MODULE_SIG_SHA1 is not set/CONFIG_MODULE_SIG_SHA1=y/' ./.config
+    sed -i -e 's/CONFIG_MODULE_SIG_HASH="sha512"/CONFIG_MODULE_SIG_HASH="sha1"/' ./.config
   fi
   # Skip dbg package creation on non-Arch
   if [ "$_distro" != "Arch" ]; then
     sed -i -e 's/CONFIG_DEBUG_INFO.*/CONFIG_DEBUG_INFO=n/' ./.config
   fi
   if [ "$_compiler_name" = "-llvm" ]; then
+    echo 'CONFIG_KCSAN=n' >> ./.config
     if [ "$_basever" != "54" ] && [ "$_basever" != "57" ] && [ "$_basever" != "58" ]; then
       echo 'CONFIG_INIT_STACK_ALL_PATTERN=n' >> ./.config
     else


### PR DESCRIPTION
also move Void LibreSSL out of noccache check so it still runs if ccache
is set off
Thanks to @Kodehawa for pointing this out, since LLVM11 is on Arch now :frog: 