### PR TITLE
Blacklist $_path from installed config

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -428,8 +428,8 @@ build() {
     msg2 'ccache was found and will be used'
   fi
 
-  # document the TkG variables, excluding "_", "_EXT_CONFIG_PATH", and "_where".
-  declare -p | cut -d ' ' -f 3 | grep -P '^_(?!=|EXT_CONFIG_PATH|where)' > "${srcdir}/customization-full.cfg"
+  # document the TkG variables, excluding "_", "_EXT_CONFIG_PATH", "_where", and "_path".
+  declare -p | cut -d ' ' -f 3 | grep -P '^_(?!=|EXT_CONFIG_PATH|where|path)' > "${srcdir}/customization-full.cfg"
 
   # remove -O2 flag and place user optimization flag
   CFLAGS=${CFLAGS/-O2/}


### PR DESCRIPTION
It was decided [here](https://github.com/Frogging-Family/linux-tkg/pull/49#issuecomment-677631969) that we would like to not include the build path in the built package. This PR upholds this by adding an exception for `$_path` to `customization-full.cfg`.

Cheers ^.^