### PR TITLE
do not urlencode gcc patch version and link

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,16 +39,16 @@ case "$_basever" in
 	opt_ver="4.19-v5.4"
 	;;
 	"57")
-	opt_ver="5.7%2B"
+	opt_ver="5.7+"
 	;;
 	"58")
-	opt_ver="5.8%2B"
+	opt_ver="5.8+"
 	;;
 	"59")
-	opt_ver="5.8%2B"
+	opt_ver="5.8+"
 	;;
 	"510")
-	opt_ver="5.8%2B"
+	opt_ver="5.8+"
 	;;
 esac
 

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -365,7 +365,7 @@ _tkg_srcprep() {
   elif [ "${_distro}" = "Void" ]; then
     tkgpatch="${wrksrc}/enable_additional_cpu_optimizations_for_gcc_v10.1+_kernel_v${opt_ver}.patch" && _tkg_patcher
   else
-    tkgpatch="$srcdir/enable_additional_cpu_optimizations_for_gcc_v10.1+_kernel_v${opt_ver}+.patch" && _tkg_patcher
+    tkgpatch="$srcdir/enable_additional_cpu_optimizations_for_gcc_v10.1+_kernel_v${opt_ver}.patch" && _tkg_patcher
   fi
   
 


### PR DESCRIPTION
Wget can handle none urlencoded urls and the gcc patch was not applied
in some cases because the urlencoded file path was not properly handled
after downloading.