### PR TITLE
Simplify cpu marchs and enable for LLVM

### DIFF
--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -358,16 +358,16 @@ _tkg_srcprep() {
   fi
 
   # graysky's cpu opts - https://github.com/graysky2/kernel_gcc_patch
-  if [ "$_compiler_name" != "-llvm" ]; then
-    msg2 "Applying graysky's cpu opts patch"
-    if [ "${_distro}" = "Arch" ]; then
-      tkgpatch="$srcdir/enable_additional_cpu_optimizations_for_gcc_v10.1%2B_kernel_v${opt_ver}.patch" && _tkg_patcher
-    elif [ "${_distro}" = "Void" ]; then
-      tkgpatch="${wrksrc}/enable_additional_cpu_optimizations_for_gcc_v10.1+_kernel_v${opt_ver}.patch" && _tkg_patcher
-    else
-      tkgpatch="$srcdir/enable_additional_cpu_optimizations_for_gcc_v10.1+_kernel_v${opt_ver}+.patch" && _tkg_patcher
-    fi
+  
+  msg2 "Applying graysky's cpu opts patch"
+  if [ "${_distro}" = "Arch" ]; then
+    tkgpatch="$srcdir/enable_additional_cpu_optimizations_for_gcc_v10.1%2B_kernel_v${opt_ver}.patch" && _tkg_patcher
+  elif [ "${_distro}" = "Void" ]; then
+    tkgpatch="${wrksrc}/enable_additional_cpu_optimizations_for_gcc_v10.1+_kernel_v${opt_ver}.patch" && _tkg_patcher
+  else
+    tkgpatch="$srcdir/enable_additional_cpu_optimizations_for_gcc_v10.1+_kernel_v${opt_ver}+.patch" && _tkg_patcher
   fi
+  
 
   # TkG
   msg2 "Applying clear linux patches"
@@ -538,37 +538,35 @@ _tkg_srcprep() {
     sed -i -e 's/CONFIG_FONT_TER16x32=y/# CONFIG_FONT_TER16x32 is not set\nCONFIG_FONT_AUTOSELECT=y/' ./.config
   fi
 
-  # Inject cpuopts options
-  if [ "$_compiler_name" != "-llvm" ]; then
-    echo "# CONFIG_MK8SSE3 is not set" >> ./.config
-    echo "# CONFIG_MK10 is not set" >> ./.config
-    echo "# CONFIG_MBARCELONA is not set" >> ./.config
-    echo "# CONFIG_MBOBCAT is not set" >> ./.config
-    echo "# CONFIG_MJAGUAR is not set" >> ./.config
-    echo "# CONFIG_MBULLDOZER is not set" >> ./.config
-    echo "# CONFIG_MPILEDRIVER is not set" >> ./.config
-    echo "# CONFIG_MSTEAMROLLER is not set" >> ./.config
-    echo "# CONFIG_MEXCAVATOR is not set" >> ./.config
-    echo "# CONFIG_MZEN is not set" >> ./.config
-    echo "# CONFIG_MZEN2 is not set" >> ./.config
-    echo "# CONFIG_MATOM is not set" >> ./.config
-    echo "# CONFIG_MNEHALEM is not set" >> ./.config
-    echo "# CONFIG_MWESTMERE is not set" >> ./.config
-    echo "# CONFIG_MSILVERMONT is not set" >> ./.config
-    echo "# CONFIG_MSANDYBRIDGE is not set" >> ./.config
-    echo "# CONFIG_MIVYBRIDGE is not set" >> ./.config
-    echo "# CONFIG_MHASWELL is not set" >> ./.config
-    echo "# CONFIG_MBROADWELL is not set" >> ./.config
-    echo "# CONFIG_MSKYLAKE is not set" >> ./.config
-    echo "# CONFIG_MSKYLAKEX is not set" >> ./.config
-    echo "# CONFIG_MCANNONLAKE is not set" >> ./.config
-    echo "# CONFIG_MICELAKE is not set" >> ./.config
-    echo "# CONFIG_MGOLDMONT is not set" >> ./.config
-    echo "# CONFIG_MGOLDMONTPLUS is not set" >> ./.config
-    echo "# CONFIG_MCASCADELAKE is not set" >> ./.config
-    echo "# CONFIG_MCOOPERLAKE is not set" >> ./.config
-    echo "# CONFIG_MTIGERLAKE is not set" >> ./.config
+  # cpu opt
+
+  if [ -n "$_processor_opt" ] && [ "$_processor_opt" != "native" ]; then
+    echo "# CONFIG_MNATIVE is not set" >> ./.config
   fi
+
+  if [ -n "$_processor_opt" ] && [ "$_processor_opt" != "generic" ]; then
+    sed -i -e 's/CONFIG_GENERIC_CPU=y/# CONFIG_GENERIC_CPU is not set/' ./.config
+  fi
+
+  if [ "$_processor_opt" = "native" ]; then
+    echo "CONFIG_MNATIVE=y" >> ./.config
+  fi  
+
+  _cpu_marchs=("k8" "k8sse3" "k10" "barcelona" "bobcat" "jaguar" "bulldozer" "piledriver")
+  _cpu_marchs+=("steamroller" "excavator" "zen" "zen2" "mpsc" "atom" "core2" "nehalem" "westmere")
+  _cpu_marchs+=("silvermont" "sandybridge" "ivybridge" "haswell" "broadwell" "skylake")
+  _cpu_marchs+=("skylakex" "cannonlake" "icelake" "goldmont" "goldmontplus" "cascadelake")
+  _cpu_marchs+=("cooperlake" "tigerlake")
+
+  for _march in "${_cpu_marchs[@]}"
+  do
+    _march_upper=`echo ${_march} | tr '[:lower:]' '[:upper:]'`
+    if [ "$_processor_opt" = "$_march" ]; then
+      echo "CONFIG_M${_march_upper}=y/" >> ./.config
+    else
+      echo "# CONFIG_M${_march_upper} is not set" >> ./.config
+    fi
+  done  
 
   # Disable some debugging
   if [ "${_debugdisable}" = "true" ]; then
@@ -746,81 +744,6 @@ _tkg_srcprep() {
     else
       echo "# CONFIG_CC_OPTIMIZE_HARDER is not set" >> ./.config
     fi
-  fi
-
-  # cpu opt
-  if [ -n "$_processor_opt" ] && [ "$_processor_opt" != "native" ]; then
-    echo "# CONFIG_MNATIVE is not set" >> ./.config
-  fi
-
-  if [ -n "$_processor_opt" ] && [ "$_processor_opt" != "generic" ]; then
-    sed -i -e 's/CONFIG_GENERIC_CPU=y/# CONFIG_GENERIC_CPU is not set/' ./.config
-  fi
-
-  if [ "$_processor_opt" = "native" ]; then
-    echo "CONFIG_MNATIVE=y" >> ./.config
-  elif [ "$_processor_opt" = "k8" ]; then
-    sed -i -e 's/# CONFIG_MK8 is not set/CONFIG_MK8=y/' ./.config
-  elif [ "$_processor_opt" = "k8sse3" ]; then
-    sed -i -e 's/# CONFIG_MK8SSE3 is not set/CONFIG_MK8SSE3=y/' ./.config
-  elif [ "$_processor_opt" = "k10" ]; then
-    sed -i -e 's/# CONFIG_MK10 is not set/CONFIG_MK10=y/' ./.config
-  elif [ "$_processor_opt" = "barcelona" ]; then
-    sed -i -e 's/# CONFIG_MBARCELONA is not set/CONFIG_MBARCELONA=y/' ./.config
-  elif [ "$_processor_opt" = "bobcat" ]; then
-    sed -i -e 's/# CONFIG_MBOBCAT is not set/CONFIG_MBOBCAT=y/' ./.config
-  elif [ "$_processor_opt" = "jaguar" ]; then
-    sed -i -e 's/# CONFIG_MJAGUAR is not set/CONFIG_MJAGUAR=y/' ./.config
-  elif [ "$_processor_opt" = "bulldozer" ]; then
-    sed -i -e 's/# CONFIG_MBULLDOZER is not set/CONFIG_MBULLDOZER=y/' ./.config
-  elif [ "$_processor_opt" = "piledriver" ]; then
-    sed -i -e 's/# CONFIG_MPILEDRIVER is not set/CONFIG_MPILEDRIVER=y/' ./.config
-  elif [ "$_processor_opt" = "steamroller" ]; then
-    sed -i -e 's/# CONFIG_MSTEAMROLLER is not set/CONFIG_MSTEAMROLLER=y/' ./.config
-  elif [ "$_processor_opt" = "excavator" ]; then
-    sed -i -e 's/# CONFIG_MEXCAVATOR is not set/CONFIG_MEXCAVATOR=y/' ./.config
-  elif [ "$_processor_opt" = "zen" ]; then
-    sed -i -e 's/# CONFIG_MZEN is not set/CONFIG_MZEN=y/' ./.config
-  elif [ "$_processor_opt" = "zen2" ]; then
-    sed -i -e 's/# CONFIG_MZEN2 is not set/CONFIG_MZEN2=y/' ./.config
-  elif [ "$_processor_opt" = "mpsc" ]; then
-    sed -i -e 's/# CONFIG_MPSC is not set/CONFIG_MPSC=y/' ./.config
-  elif [ "$_processor_opt" = "atom" ]; then
-    sed -i -e 's/# CONFIG_MATOM is not set/CONFIG_MATOM=y/' ./.config
-  elif [ "$_processor_opt" = "core2" ]; then
-    sed -i -e 's/# CONFIG_MCORE2 is not set/CONFIG_MCORE2=y/' ./.config
-  elif [ "$_processor_opt" = "nehalem" ]; then
-    sed -i -e 's/# CONFIG_MNEHALEM is not set/CONFIG_MNEHALEM=y/' ./.config
-  elif [ "$_processor_opt" = "westmere" ]; then
-    sed -i -e 's/# CONFIG_MWESTMERE is not set/CONFIG_MWESTMERE=y/' ./.config
-  elif [ "$_processor_opt" = "silvermont" ]; then
-    sed -i -e 's/# CONFIG_MSILVERMONT is not set/CONFIG_MSILVERMONT=y/' ./.config
-  elif [ "$_processor_opt" = "sandybridge" ]; then
-    sed -i -e 's/# CONFIG_MSANDYBRIDGE is not set/CONFIG_MSANDYBRIDGE=y/' ./.config
-  elif [ "$_processor_opt" = "ivybridge" ]; then
-    sed -i -e 's/# CONFIG_MIVYBRIDGE is not set/CONFIG_MIVYBRIDGE=y/' ./.config
-  elif [ "$_processor_opt" = "haswell" ]; then
-    sed -i -e 's/# CONFIG_MHASWELL is not set/CONFIG_MHASWELL=y/' ./.config
-  elif [ "$_processor_opt" = "broadwell" ]; then
-    sed -i -e 's/# CONFIG_MBROADWELL is not set/CONFIG_MBROADWELL=y/' ./.config
-  elif [ "$_processor_opt" = "skylake" ]; then
-    sed -i -e 's/# CONFIG_MSKYLAKE is not set/CONFIG_MSKYLAKE=y/' ./.config
-  elif [ "$_processor_opt" = "skylakex" ]; then
-    sed -i -e 's/# CONFIG_MSKYLAKEX is not set/CONFIG_MSKYLAKEX=y/' ./.config
-  elif [ "$_processor_opt" = "cannonlake" ]; then
-    sed -i -e 's/# CONFIG_MCANNONLAKE is not set/CONFIG_MCANNONLAKE=y/' ./.config
-  elif [ "$_processor_opt" = "icelake" ]; then
-    sed -i -e 's/# CONFIG_MICELAKE is not set/CONFIG_MICELAKE=y/' ./.config
-  elif [ "$_processor_opt" = "goldmont" ]; then
-    sed -i -e 's/# CONFIG_MGOLDMONT is not set/CONFIG_MGOLDMONT=y/' ./.config
-  elif [ "$_processor_opt" = "goldmontplus" ]; then
-    sed -i -e 's/# CONFIG_MGOLDMONTPLUS is not set/CONFIG_MGOLDMONTPLUS=y/' ./.config
-  elif [ "$_processor_opt" = "cascadelake" ]; then
-    sed -i -e 's/# CONFIG_MCASCADELAKE is not set/CONFIG_MCASCADELAKE=y/' ./.config
-  elif [ "$_processor_opt" = "cooperlake" ]; then
-    sed -i -e 's/# CONFIG_MCOOPERLAKE is not set/CONFIG_MCOOPERLAKE=y/' ./.config
-  elif [ "$_processor_opt" = "tigerlake" ]; then
-    sed -i -e 's/# CONFIG_MTIGERLAKE is not set/CONFIG_MTIGERLAKE=y/' ./.config
   fi
 
   # irq threading


### PR DESCRIPTION
Hello!

I simplified the `-march=XX` code path with an array. I retested the graysky patch with LLVM and it works without any issue, the kernel compiles and the clang compiler does receive the `-march=xx` option. I also [reported](https://github.com/graysky2/kernel_gcc_patch/issues/57) it in an issue on graysky's repository.

See ya for another PR,

Adel