### PR TITLE
5.10.13

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -317,7 +317,7 @@ case $_basever in
         0012-misc-additions.patch
     )
     sha256sums=('dcdf99e43e98330d925016985bfbc7b83c66d367b714b2de0cbbfcbf83d8ca43'
-            '21e4e5e4286494f230c46efb198da34a0f25e13bd40606f4597e53434a29c6fe'
+            'daeb7733a16d2e6198f9201655bf7eb6a2cb0e1babc38c50ab1a3fbf789187a7'
             'SKIP'
             '458d1ca195f3fee5501683a4b61ef0ed0cfa7e5219eccab3390fb40c0289898a'
             'eb1da1a028a1c967222b5bdac1db2b2c4d8285bafd714892f6fc821c10416341'
@@ -342,7 +342,7 @@ case $_basever in
             'e308292fc42840a2366280ea7cf26314e92b931bb11f04ad4830276fc0326ee1'
             '49262ce4a8089fa70275aad742fc914baa28d9c384f710c9a62f64796d13e104'
             '105f51e904d80f63c1421203e093b612fc724edefd3e388b64f8d371c0b3a842'
-            'a39f952930394cbc6a71ecf166eb0ade5835e82690669161f0437d7f72ceb3aa')
+            '7fb1104c167edb79ec8fbdcde97940ed0f806aa978bdd14d0c665a1d76d25c24')
 	;;
 	511)
 	opt_ver="5.8%2B"

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -4,7 +4,7 @@ ver54=94
 ver57=19
 ver58=18
 ver59=16
-ver510=12
+ver510=13
 ver511=rc6
 
 _tkg_initscript() {

--- a/linux-tkg-patches/5.10/0012-misc-additions.patch
+++ b/linux-tkg-patches/5.10/0012-misc-additions.patch
@@ -34,40 +34,6 @@ index bf7ecab5d9e5..142e9dae2837 100644
 -- 
 cgit v1.2.3-1-gf6bb5
 
-From 61e5f6548784e507eb0662a71976a673436e6e3a Mon Sep 17 00:00:00 2001
-From: Eric Dumazet <edumazet@google.com>
-Date: Mon, 21 Dec 2020 20:14:02 +0100
-Subject: iwlwifi: Fix regression from UDP segmentation support
-
-Eric's tentative fix from
-https://lore.kernel.org/linux-wireless/CANn89iJWG2n1s3j7EdpwkQQv-9dOY02V+FGYHAWguO4JiqWuJA@mail.gmail.com/
----
- drivers/net/wireless/intel/iwlwifi/mvm/tx.c | 2 ++
- 1 file changed, 2 insertions(+)
-
-diff --git a/drivers/net/wireless/intel/iwlwifi/mvm/tx.c b/drivers/net/wireless/intel/iwlwifi/mvm/tx.c
-index fe1c538cd718..c27743a58f81 100644
---- a/drivers/net/wireless/intel/iwlwifi/mvm/tx.c
-+++ b/drivers/net/wireless/intel/iwlwifi/mvm/tx.c
-@@ -833,6 +833,7 @@ iwl_mvm_tx_tso_segment(struct sk_buff *skb, unsigned int num_subframes,
- 
- 	next = skb_gso_segment(skb, netdev_flags);
- 	skb_shinfo(skb)->gso_size = mss;
-+       skb_shinfo(skb)->gso_type = ipv4 ? SKB_GSO_TCPV4 : SKB_GSO_TCPV6;
- 	if (WARN_ON_ONCE(IS_ERR(next)))
- 		return -EINVAL;
- 	else if (next)
-@@ -855,6 +856,7 @@ iwl_mvm_tx_tso_segment(struct sk_buff *skb, unsigned int num_subframes,
- 
- 		if (tcp_payload_len > mss) {
- 			skb_shinfo(tmp)->gso_size = mss;
-+                       skb_shinfo(tmp)->gso_type = ipv4 ? SKB_GSO_TCPV4 : SKB_GSO_TCPV6;
- 		} else {
- 			if (qos) {
- 				u8 *qc;
--- 
-cgit v1.2.3-1-gf6bb5
-
 From e437ac931e89629f952ce9f3f9dfe45ac505cd0d Mon Sep 17 00:00:00 2001
 From: Joshua Ashton <joshua@froggi.es>
 Date: Tue, 5 Jan 2021 19:46:01 +0000


### PR DESCRIPTION
Looks like the patch for the regression in iwlwifi is in 5.10.13, removed it from the misc additions patch