### PR TITLE
install.sh: add googlesource.com git mirror and code cleanup

### DIFF
--- a/customization.cfg
+++ b/customization.cfg
@@ -17,6 +17,9 @@ _EXT_CONFIG_PATH=~/.config/frogminer/linux-tkg.cfg
 # Default is "true".
 _NUKR="true"
 
+# [install.sh specific] Git mirror to use to get the kernel sources, possible values are "googlesource.com" and "kernel.org"
+_git_mirror="kernel.org"
+
 # Custom compiler root dirs - Leave empty to use system compilers
 # Example: CUSTOM_GCC_PATH="/home/frog/PKGBUILDS/mostlyportable-gcc/gcc-mostlyportable-9.2.0"
 CUSTOM_GCC_PATH=""


### PR DESCRIPTION
Hello,

I added the `googlesource.com` mirror to `install.sh`, this should close #181. I also refactored the `sub=0` code path into fewer lines. I will PR later on the ability to use `tar` source code if people wish to use the `/tmp` ramfs folder.

Adel