### PR TITLE
Add GCC version future version support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -250,7 +250,7 @@ if [ "$1" = "install" ] || [ "$1" = "config" ]; then
   esac
 
   if [ "$opt_alternative_url" != "true" ]; then
-    wget "https://raw.githubusercontent.com/graysky2/kernel_gcc_patch/master/more-uarches-for-gcc-v10-and-kernel-${opt_ver}.patch"
+    wget "https://raw.githubusercontent.com/graysky2/kernel_gcc_patch/master/more-uarches-for-gcc-v" && gcc -dumpversion && "-and-kernel-${opt_ver}.patch"
   else
     wget "https://raw.githubusercontent.com/graysky2/kernel_gcc_patch/master/outdated_versions/enable_additional_cpu_optimizations_for_gcc_v10.1+_kernel_v${opt_ver}.patch"
   fi


### PR DESCRIPTION
Fedora 34 and Rawhide both use GCC version 11, I have simply added a GCC version check which allows for older and newer versions to be checked with the CPU optimizations patch.