### PR TITLE
Some extra features for convenience 

### DIFF
--- a/customization.cfg
+++ b/customization.cfg
@@ -44,6 +44,9 @@ _noccache="false"
 # !!!! Make sure to have a well populated db !!!! - Leave empty to be asked about it at build time
 _modprobeddb="false"
 
+# modprobed-db database file location
+_modprobeddb_db_path=~/.config/modprobed.db
+
 # Set to "1" to call make menuconfig, "2" to call make nconfig, "3" to call make xconfig, before building the kernel. Set to false to disable and skip the prompt.
 _menunconfig=""
 

--- a/customization.cfg
+++ b/customization.cfg
@@ -58,9 +58,16 @@ _diffconfig_name=""
 
 #### KERNEL OPTIONS ####
 
-# [Arch specific] Name of the default config file to use from the linux???-tkg-config folder. 
-# Default is "config.x86_64" and Arch hardened is "config_hardened.x86_64".
-# To get a complete hardened setup, you have to use "cfs" as _cpusched
+# Name of the default config file to use for the kernel
+# Default (empty):
+# - Archlinux (PKGBUILD): "config.x86_64" from the linux-tkg-config/5.y folder.
+# - install.sh: Picks the .config file from the currently running kernel. 
+#               It is recommended to be running an official kernel before running this script, to pick off a correct .config file
+# User provided: 
+# - Archlinux : use "config_hardened.x86_64" to get a hardened kernel. To get a complete hardened setup, you have to use "cfs" as _cpusched.
+# - Any : custom user provided file, the given path should be relative to the PKGBUILD file. This enables for example to use a user stripped down .config file. 
+#         If the .config file isn't up to date with the chosen kernel version, any extra CONFIG_XXXX is set to its default value.
+# Note: the script produces a .config.new file that is copied next to the PKGBUILD as a convenience for an eventual re-use. It gets overwritten at each run.
 _configfile=""
 
 # Disable some non-module debugging - See PKGBUILD for the list

--- a/customization.cfg
+++ b/customization.cfg
@@ -67,7 +67,8 @@ _diffconfig_name=""
 # - Archlinux : use "config_hardened.x86_64" to get a hardened kernel. To get a complete hardened setup, you have to use "cfs" as _cpusched.
 # - Any : custom user provided file, the given path should be relative to the PKGBUILD file. This enables for example to use a user stripped down .config file. 
 #         If the .config file isn't up to date with the chosen kernel version, any extra CONFIG_XXXX is set to its default value.
-# Note: the script produces a .config.new file that is copied next to the PKGBUILD as a convenience for an eventual re-use. It gets overwritten at each run.
+# Note: the script copies the resulting .config file as "kernelconfig.new" next to the PKGBUILD as a convenience for an eventual re-use. It gets overwritten at each run.
+#       One can use "kernelconfig.new" here to always use the latest edited .config file. modprobed-db needs to be used only once for its changes to be picked up.
 _configfile=""
 
 # Disable some non-module debugging - See PKGBUILD for the list

--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@ warning() {
 }
 
 plain() {
- echo "$1" >&2
+ echo -e "$1" >&2
 }
 
 _distro_prompt() {

--- a/install.sh
+++ b/install.sh
@@ -260,11 +260,6 @@ if [ "$1" = "install" ] || [ "$1" = "config" ]; then
   # cd in linux folder, copy Ubuntu's current config file, update with new params
   cd "$_where"/linux-src-git
 
-  if ( msg2 "Trying /boot/config-* ..." && cp /boot/config-`uname -r` .config ) || ( msg2 "Trying /proc/config.gz ..." && zcat --verbose /proc/config.gz > .config ); then
-    msg2 "Copying current kernel's config and running make oldconfig..."
-  else
-    msg2 "Current kernel config not found! Falling back to default..."
-  fi
   if [ "$_distro" = "Debian" ]; then 
     #Help Debian cert compile problem.
     sed -i -e 's#CONFIG_SYSTEM_TRUSTED_KEYS="debian/certs/test-signing-certs.pem"#CONFIG_SYSTEM_TRUSTED_KEYS=""#g' .config 

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -1308,7 +1308,7 @@ CONFIG_DEBUG_INFO_BTF_MODULES=y\n
   fi
 
   # copy new config file back to the user's git folder for an eventual future use
-  cp .config "${_where}"/.config.new
+  cp .config "${_where}"/kernelconfig.new
 }
 
 exit_cleanup() {

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -1290,6 +1290,9 @@ CONFIG_DEBUG_INFO_BTF_MODULES=y\n
     make -s kernelrelease > version
     msg2 "Prepared %s version %s" "$pkgbase" "$(<version)"
   fi
+
+  # copy new config file back to the user's git folder for an eventual future use
+  cp .config "${_where}"/.config.new
 }
 
 exit_cleanup() {

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -1190,7 +1190,11 @@ CONFIG_DEBUG_INFO_BTF_MODULES=y\n
     read -rp "`echo $'    > N/y : '`" CONDITIONMPDB;
   fi
   if [[ "$CONDITIONMPDB" =~ [yY] ]] || [ "$_modprobeddb" = "true" ]; then
-    yes "" | make LSMOD=${HOME}/.config/modprobed.db localmodconfig ${llvm_opt}
+    if [ ! -f $_modprobeddb_db_path ]; then
+      msg2 "modprobed-db database not found"
+      exit 1
+    fi
+    yes "" | make LSMOD=$_modprobeddb_db_path localmodconfig ${llvm_opt}
   fi
 
   if [ true = "$_config_fragments" ]; then

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -493,11 +493,22 @@ _tkg_srcprep() {
     cd ${wrksrc}/linux-${_kern_ver}
   fi
 
-  if [ "${_distro}" = "Arch" ] || [ "$_distro" = "Void" ]; then
-    if [ -z "${_configfile}" ]; then
-      _configfile="config.x86_64"
+  
+  if [ -z "${_configfile}" ]; then    
+    if [ "${_distro}" = "Arch" ] || [ "$_distro" = "Void" ]; then
+      cat "${srcdir}"/config.x86_64 > ./.config
+    else
+      if [ -f /boot/config-`uname -r` ];then
+        msg2 "Using /boot/config-`uname -r` as config file"
+        cp /boot/config-`uname -r` .config
+      elif [ -f /proc/config.gz ];then
+        msg2 "Using /proc/config.gz as config file"
+        zcat --verbose /proc/config.gz > .config
+      else
+        msg2 "Current kernel config not found! Falling back to default..."
+      fi
     fi
-
+  else
     cat "${srcdir}/${_configfile}" > ./.config
   fi
 

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -336,9 +336,11 @@ _tkg_srcprep() {
     exit 1
   fi
 
+  msg2 "Setting version..."
+  scripts/setlocalversion --save-scmversion
+  
   if [ "${_distro}" = "Arch" ]; then
-    msg2 "Setting version..."
-    scripts/setlocalversion --save-scmversion
+    
     echo "-$pkgrel-tkg-${_cpusched}${_compiler_name}" > localversion.10-pkgrel
     echo -e "Version tail set to \"-$pkgrel-tkg-${_cpusched}${_compiler_name}\"\n" > "$_where"/prepare.log
     echo "" > localversion.20-pkgname
@@ -1190,6 +1192,9 @@ CONFIG_DEBUG_INFO_BTF_MODULES=y\n
     read -rp "`echo $'    > N/y : '`" CONDITIONMPDB;
   fi
   if [[ "$CONDITIONMPDB" =~ [yY] ]] || [ "$_modprobeddb" = "true" ]; then
+    if [ -f "$where"/"$_modprobeddb_db_path" ];then
+      _modprobeddb_db_path="$where"/"$_modprobeddb_db_path"
+    fi
     if [ ! -f $_modprobeddb_db_path ]; then
       msg2 "modprobed-db database not found"
       exit 1


### PR DESCRIPTION
Hello!

Some extra features that I personally find handy:
- Have the script copy the generated `.config` file next to the PKGBUILD, as `.config.new` so I can save it somewhere, after I did some various changes with `make xconfig`. I find the final `.config` file more useful than frags because the originally used `.config` file is not constant in non arch. 
- With the previous feature, the next step is to enable `install.sh` to use such custom `.config` files.
- Fixed an issue with `install.sh` where the prompt for the kernel version doesn't do newlines
- Enable `setversion` for `install.sh`, it may fix #173 and fix #204 actually.
- Enable using user provided `modprobed.db` databases, to compile stripped down kernels for friends.

What do you think of all this ?