### PR TITLE
 Fix Debian / Ubuntu compile due to .config

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -260,16 +260,7 @@ if [ "$1" = "install" ] || [ "$1" = "config" ]; then
   # cd in linux folder, copy Ubuntu's current config file, update with new params
   cd "$_where"/linux-src-git
 
-  if [ "$_distro" = "Debian" ]; then 
-    #Help Debian cert compile problem.
-    sed -i -e 's#CONFIG_SYSTEM_TRUSTED_KEYS="debian/certs/test-signing-certs.pem"#CONFIG_SYSTEM_TRUSTED_KEYS=""#g' .config 
-    #Help Debian UEFI cert compile problem
-    sed -i -e 's#CONFIG_SYSTEM_TRUSTED_KEYS="debian/certs/debian-uefi-certs.pem"#CONFIG_SYSTEM_TRUSTED_KEYS=""#g' .config
-  fi
- if [ "$_distro" = "Ubuntu" ]; then 
-    #Help Ubuntu cert compile problem.
-    sed -i -e 's#CONFIG_SYSTEM_TRUSTED_KEYS="debian/canonical-certs.pem"#CONFIG_SYSTEM_TRUSTED_KEYS=""#g' .config 
-  fi
+
   yes '' | make ${llvm_opt} oldconfig
   msg2 "Done"
 

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -642,6 +642,18 @@ CONFIG_DEBUG_INFO_BTF_MODULES=y\n
     sed -i -e 's/# CONFIG_MODULE_SIG_SHA1 is not set/CONFIG_MODULE_SIG_SHA1=y/' ./.config
     sed -i -e 's/CONFIG_MODULE_SIG_HASH="sha512"/CONFIG_MODULE_SIG_HASH="sha1"/' ./.config
   fi
+  # Prevent Debian to sign certs (Bios/UEFI) 
+  if [ "$_distro" = "Debian" ]; then 
+    #Help Debian cert compile problem.
+    sed -i -e 's#CONFIG_SYSTEM_TRUSTED_KEYS="debian/certs/test-signing-certs.pem"#CONFIG_SYSTEM_TRUSTED_KEYS=""#g' .config 
+    #Help Debian UEFI cert compile problem
+    sed -i -e 's#CONFIG_SYSTEM_TRUSTED_KEYS="debian/certs/debian-uefi-certs.pem"#CONFIG_SYSTEM_TRUSTED_KEYS=""#g' .config
+  fi
+  # Latest versions of Ubuntu require Canonical certifications.
+  if [ "$_distro" = "Ubuntu" ]; then 
+    #Help Ubuntu cert compile problem.
+    sed -i -e 's#CONFIG_SYSTEM_TRUSTED_KEYS="debian/canonical-certs.pem"#CONFIG_SYSTEM_TRUSTED_KEYS=""#g' .config 
+  fi
   # Skip dbg package creation on non-Arch
   if [ "$_distro" != "Arch" ]; then
     sed -i -e 's/CONFIG_DEBUG_INFO.*/CONFIG_DEBUG_INFO=n/' ./.config


### PR DESCRIPTION
Since the moment in which .config is created was changed, I transferred the Debian and Ubuntu workarounds to Prepare, it did not compile because it could not find the .conf when doing "sed"