### PR TITLE
Arch: Fix failure to extract kernel patch when srcdest is set in makepkg.conf

### DIFF
--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -349,7 +349,11 @@ _tkg_srcprep() {
     if [ "$_sub" != "0" ] && [[ "$_sub" != rc* ]]; then
       msg2 "Patching from $_basekernel to $pkgver"
       if [ ! -e "$srcdir/patch-${pkgver}" ]; then
-        ( cd "$_where" && xz -dk patch-${pkgver}.xz && mv "$_where"/patch-${pkgver} "$srcdir"/ )
+        if [ -e "$srcdir/patch-${pkgver}.xz" ]; then
+          xz -dk "$(readlink -f "$srcdir/patch-${pkgver}.xz")" --stdout > "$srcdir/patch-${pkgver}"
+        else
+          ( cd "$_where" && xz -dk patch-${pkgver}.xz && mv "$_where"/patch-${pkgver} "$srcdir"/ )
+        fi
       fi
       tkgpatch="$srcdir/patch-${pkgver}" && _tkg_patcher
     fi


### PR DESCRIPTION
On my machine, the kernel fails to build when srcdest is set in makepkg. My solution was to check the source folder and extract the upstream patch if the extracted patch is missing.

I am open to any changes.