### PR TITLE
install.sh: improve git fetching and stop producing source code packages

### DIFF
--- a/customization.cfg
+++ b/customization.cfg
@@ -1,6 +1,6 @@
 # linux-TkG config file
 
-# Linux distribution you are using, options are "Arch", "Void", "Ubuntu", "Debian", "Fedora" or "Suse". 
+# Linux distribution you are using, options are "Arch", "Void", "Ubuntu", "Debian", "Fedora" or "Suse".
 # It is automatically set to "Arch" when using PKGBUILD.
 # If left empty, the script will prompt
 _distro=""
@@ -200,7 +200,7 @@ _custom_commandline="intel_pstate=passive"
 _custom_pkgbase=""
 
 # [non-Arch specific] Kernel localversion. Putting it to "Mario" will make for example the kernel version be 5.7.0-tkg-Mario (given by uname -r)
-# If left empty, it will use -tkg-"${_cpusched}" where "${_cpusched}" will be replaced by the user chosen scheduler
+# If left empty, it will use "-tkg-${_cpusched}${_compiler}" where "${_cpusched}" will be replaced by the user chosen scheduler, ${_compiler} will be replaced by "-llvm" if clang is used (nothing for GCC).
 _kernel_localversion=""
 
 #### USER PATCHES ####

--- a/install.sh
+++ b/install.sh
@@ -175,11 +175,11 @@ srcdir="$_where"
 
 source customization.cfg
 
-source linux-tkg-config/prepare 
+source linux-tkg-config/prepare
 
 if [ "$1" != "install" ] && [ "$1" != "config" ] && [ "$1" != "uninstall-help" ]; then
   msg2 "Argument not recognised, options are:
-        - config : interactive script that shallow clones the linux 5.x.y git tree into the folder linux-src-git, then applies extra patches and prepares the .config file 
+        - config : interactive script that shallow clones the linux 5.x.y git tree into the folder linux-src-git, then applies extra patches and prepares the .config file
                    by copying the one from the currently running linux system and updates it. 
         - install : [for RPM and DEB based distros only], does the config step, proceeds to compile, then prompts to install
         - uninstall-help : [for RPM and DEB based distros only], lists the installed kernels in this system, then gives hints on how to uninstall them manually."
@@ -205,7 +205,7 @@ if [ "$1" = "install" ] || [ "$1" = "config" ]; then
   # Run init script that is also run in PKGBUILD, it will define some env vars that we will use
   _tkg_initscript
 
-  if [[ $1 = "install" && "$_distro" != "Ubuntu" && "$_distro" != "Debian" &&  "$_distro" != "Fedora" && "$_distro" != "Suse" ]]; then 
+  if [[ $1 = "install" && ! "$_distro" =~ ^(Ubuntu|Debian|Fedora|Suse)$ ]]; then
     msg2 "Variable \"_distro\" in \"customization.cfg\" hasn't been set to \"Ubuntu\", \"Debian\",  \"Fedora\" or \"Suse\""
     msg2 "This script can only install custom kernels for RPM and DEB based distros, though only those keywords are permitted. Exiting..."
     exit 0
@@ -224,7 +224,7 @@ if [ "$1" = "install" ] || [ "$1" = "config" ]; then
 
   # Git clone (if necessary) and checkout the asked branch by the user
   _linux_git_branch_checkout
-  
+
   cd "$_where"
 
   msg2 "Downloading Graysky2's CPU optimisations patch"
@@ -303,16 +303,16 @@ if [ "$1" = "install" ]; then
 
   # ccache
   if [ "$_noccache" != "true" ]; then
-
-    if [ "$_distro" = "Ubuntu" ] || [ "$_distro" = "Debian" ]; then
+    # Todo: deal with generic and paths, maybe just export boths possibilities and not care
+    if [[ "$_distro" =~ ^(Ubuntu|Debian)$ ]]; then
       export PATH="/usr/lib/ccache/bin/:$PATH"
-    elif [ "$_distro" = "Fedora" ] || [ "$_distro" = "Suse" ]; then
-      export PATH="/usr/lib64/ccache/:$PATH" 
+    elif [[ "$_distro" =~ ^(Fedora|Suse)$ ]]; then
+      export PATH="/usr/lib64/ccache/:$PATH"
     fi
 
     export CCACHE_SLOPPINESS="file_macro,locale,time_macros"
     export CCACHE_NOHASHDIR="true"
-    msg2 'ccache was found and will be used'
+    msg2 'Enabled ccache'
 
   fi
 

--- a/install.sh
+++ b/install.sh
@@ -332,14 +332,14 @@ if [ "$1" = "install" ]; then
 
   if [ "$_distro" = "Ubuntu" ]  || [ "$_distro" = "Debian" ]; then
 
-    if make ${llvm_opt} -j ${_thread_num} deb-pkg LOCALVERSION=-${_kernel_flavor}; then
+    if make ${llvm_opt} -j ${_thread_num} bindeb-pkg LOCALVERSION=-${_kernel_flavor}; then
       msg2 "Building successfully finished!"
 
       cd "$_where"
 
       # Create DEBS folder if it doesn't exist
       mkdir -p DEBS
-      
+
       # Move rpm files to RPMS folder inside the linux-tkg folder
       mv "$_where"/*.deb "$_where"/DEBS/
 
@@ -353,10 +353,9 @@ if [ "$1" = "install" ]; then
         fi
         _headers_deb="linux-headers-${_kernelname}*.deb"
         _image_deb="linux-image-${_kernelname}_*.deb"
-        _kernel_devel_deb="linux-libc-dev_${_kernelname}*.deb"
-        
+
         cd DEBS
-        sudo dpkg -i $_headers_deb $_image_deb $_kernel_devel_deb
+        sudo dpkg -i $_headers_deb $_image_deb
       fi
     fi
 
@@ -372,20 +371,20 @@ if [ "$1" = "install" ]; then
       _extra_ver_str="_${_kernel_flavor}"
     fi
 
-    if RPMOPTS="--define '_topdir ${HOME}/.cache/linux-tkg-rpmbuild'" make ${llvm_opt} -j ${_thread_num} rpm-pkg EXTRAVERSION="${_extra_ver_str}"; then
+    if RPMOPTS="--define '_topdir ${HOME}/.cache/linux-tkg-rpmbuild'" make ${llvm_opt} -j ${_thread_num} binrpm-pkg EXTRAVERSION="${_extra_ver_str}"; then
       msg2 "Building successfully finished!"
 
       cd "$_where"
 
       # Create RPMS folder if it doesn't exist
       mkdir -p RPMS
-      
+
       # Move rpm files to RPMS folder inside the linux-tkg folder
       mv ${HOME}/.cache/linux-tkg-rpmbuild/RPMS/x86_64/*tkg* "$_where"/RPMS/
 
       read -p "Do you want to install the new Kernel ? y/[n]: " _install
       if [ "$_install" = "y" ] || [ "$_install" = "Y" ] || [ "$_install" = "yes" ] || [ "$_install" = "Yes" ]; then
-        
+
         if [[ "$_sub" = rc* ]]; then
           _kernelname=$_basekernel.${_kernel_subver}_${_sub}_$_kernel_flavor
         else
@@ -393,18 +392,15 @@ if [ "$1" = "install" ]; then
         fi
         _headers_rpm="kernel-headers-${_kernelname}*.rpm"
         _kernel_rpm="kernel-${_kernelname}*.rpm"
-        _kernel_devel_rpm="kernel-devel-${_kernelname}*.rpm"
-        
+
         cd RPMS
         if [ "$_distro" = "Fedora" ]; then
-          sudo dnf install $_headers_rpm $_kernel_rpm $_kernel_devel_rpm
+          sudo dnf install $_headers_rpm $_kernel_rpm
         elif [ "$_distro" = "Suse" ]; then
-          msg2 "Some files from 'linux-glibc-devel' will be replaced by files from the custom kernel-hearders package"
-          msg2 "To revert back to the original kernel headers do 'sudo zypper install -f linux-glibc-devel'" 
-          sudo zypper install --replacefiles --allow-unsigned-rpm $_headers_rpm $_kernel_rpm $_kernel_devel_rpm
+          sudo zypper install --allow-unsigned-rpm $_headers_rpm $_kernel_rpm
         fi
-        
-        msg2 "Install successful" 
+
+        msg2 "Install successful"
       fi
     fi
   fi

--- a/install.sh
+++ b/install.sh
@@ -61,7 +61,7 @@ _install_dependencies() {
     if [ $(rpm -E %fedora) = "32" ]; then
       sudo dnf install fedpkg fedora-packager rpmdevtools ncurses-devel pesign grubby qt5-devel libXi-devel gcc-c++ git ccache flex bison elfutils-libelf-devel openssl-devel dwarves rpm-build ${clang_deps} -y
     else
-      sudo dnf install fedpkg fedora-packager rpmdevtools ncurses-devel pesign grubby libXi-devel gcc-c++ git ccache flex bison elfutils-libelf-devel elfutils-devel openssl openssl-devel dwarves rpm-build perl-devel perl-generators python3-devel make -y ${clang_deps} -y
+      sudo dnf install qt5-qtbase-devel fedpkg fedora-packager rpmdevtools ncurses-devel pesign grubby libXi-devel gcc-c++ git ccache flex bison elfutils-libelf-devel elfutils-devel openssl openssl-devel dwarves rpm-build perl-devel perl-generators python3-devel make -y ${clang_deps} -y
     fi
   elif [ "$_distro" = "Suse" ]; then
     msg2 "Installing dependencies"


### PR DESCRIPTION
Hello!

Here I am for another round of improvements on `install.sh`. On the menu:
- Now compiling `bindeb-pkg` and `binrpm-pkg` instead of `deb-pkg` and `rpm-pkg`. When I first implemented it I thought the source code ones are needed for DKMS things. But afaik only the headers are needed. It makes the packaging process, after compilation, way faster.
- Git shallow remote fetching wasn't optimal. Fixed that
- Handling two remotes in Git wasn't done properly, fixed that.
- A few uses of reggex'es to makes conditions smaller.

I tested my changes (except on Suse, I got lazy) and I think it's all good to go!

![One merge please -frog v2](https://user-images.githubusercontent.com/13605217/114752003-23e6ab00-9d56-11eb-9d46-961037769c67.png)
