### PR TITLE
install.sh: Add convenience script for generic install

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,11 @@ The command to do for that is:
 ./install.sh config
 ```
 
+If one chooses `Generic` as distro. `./install.sh install` will compile the kernel then prompt before doing the following:
+```shell
+sudo make modules_install
+sudo make install
+sudo dracut --hostonly --kver $_kernelname
+sudo grub-mkconfig -o /boot/grub/grub.cfg
+```
+

--- a/customization.cfg
+++ b/customization.cfg
@@ -1,6 +1,6 @@
 # linux-TkG config file
 
-# Linux distribution you are using, options are "Arch", "Void", "Ubuntu", "Debian", "Fedora" or "Suse".
+# Linux distribution you are using, options are "Arch", "Void", "Ubuntu", "Debian", "Fedora", "Suse", "Generic".
 # It is automatically set to "Arch" when using PKGBUILD.
 # If left empty, the script will prompt
 _distro=""
@@ -61,11 +61,11 @@ _diffconfig_name=""
 # Name of the default config file to use for the kernel
 # Default (empty):
 # - Archlinux (PKGBUILD): "config.x86_64" from the linux-tkg-config/5.y folder.
-# - install.sh: Picks the .config file from the currently running kernel. 
+# - install.sh: Picks the .config file from the currently running kernel.
 #               It is recommended to be running an official kernel before running this script, to pick off a correct .config file
-# User provided: 
+# User provided:
 # - Archlinux : use "config_hardened.x86_64" to get a hardened kernel. To get a complete hardened setup, you have to use "cfs" as _cpusched.
-# - Any : custom user provided file, the given path should be relative to the PKGBUILD file. This enables for example to use a user stripped down .config file. 
+# - Any : custom user provided file, the given path should be relative to the PKGBUILD file. This enables for example to use a user stripped down .config file.
 #         If the .config file isn't up to date with the chosen kernel version, any extra CONFIG_XXXX is set to its default value.
 # Note: the script copies the resulting .config file as "kernelconfig.new" next to the PKGBUILD as a convenience for an eventual re-use. It gets overwritten at each run.
 #       One can use "kernelconfig.new" here to always use the latest edited .config file. modprobed-db needs to be used only once for its changes to be picked up.

--- a/install.sh
+++ b/install.sh
@@ -303,17 +303,11 @@ if [ "$1" = "install" ]; then
 
   # ccache
   if [ "$_noccache" != "true" ]; then
-    # Todo: deal with generic and paths, maybe just export boths possibilities and not care
-    if [[ "$_distro" =~ ^(Ubuntu|Debian)$ ]]; then
-      export PATH="/usr/lib/ccache/bin/:$PATH"
-    elif [[ "$_distro" =~ ^(Fedora|Suse)$ ]]; then
-      export PATH="/usr/lib64/ccache/:$PATH"
-    fi
+    export PATH="/usr/lib64/ccache/:/usr/lib/ccache/bin/:$PATH"
 
     export CCACHE_SLOPPINESS="file_macro,locale,time_macros"
     export CCACHE_NOHASHDIR="true"
     msg2 'Enabled ccache'
-
   fi
 
   if [ -z $_kernel_localversion ]; then


### PR DESCRIPTION
Hello,

This is  something I personally use on my Gentoo, which is basically the generic way to install the kernel:
```shell
sudo make modules_install
sudo make install
```
I added two more commands since it's what I personally use:
```shell
sudo dracut --hostonly --kver $_kernelname
sudo grub-mkconfig -o /boot/grub/grub.cfg
```
I don't know if it can be useful for others. What do you think ?