### PR TITLE
Fix DKMS for RPM distros

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -339,7 +339,7 @@ if [ "$1" = "install" ]; then
 
       # Create DEBS folder if it doesn't exist
       mkdir -p DEBS
-      
+
       # Move rpm files to RPMS folder inside the linux-tkg folder
       mv "$_where"/*.deb "$_where"/DEBS/
 
@@ -353,7 +353,7 @@ if [ "$1" = "install" ]; then
         fi
         _headers_deb="linux-headers-${_kernelname}*.deb"
         _image_deb="linux-image-${_kernelname}_*.deb"
-        
+
         cd DEBS
         sudo dpkg -i $_headers_deb $_image_deb
       fi
@@ -378,13 +378,13 @@ if [ "$1" = "install" ]; then
 
       # Create RPMS folder if it doesn't exist
       mkdir -p RPMS
-      
+
       # Move rpm files to RPMS folder inside the linux-tkg folder
       mv ${HOME}/.cache/linux-tkg-rpmbuild/RPMS/x86_64/*tkg* "$_where"/RPMS/
 
       read -p "Do you want to install the new Kernel ? y/[n]: " _install
       if [ "$_install" = "y" ] || [ "$_install" = "Y" ] || [ "$_install" = "yes" ] || [ "$_install" = "Yes" ]; then
-        
+
         if [[ "$_sub" = rc* ]]; then
           _kernelname=$_basekernel.${_kernel_subver}_${_sub}_$_kernel_flavor
         else
@@ -393,15 +393,15 @@ if [ "$1" = "install" ]; then
         _kernel_rpm="kernel-${_kernelname}*.rpm"
         # The headers are actually contained in the kernel-devel RPM and not the headers one...
         _kernel_devel_rpm="kernel-devel-${_kernelname}*.rpm"
-        
+
         cd RPMS
         if [ "$_distro" = "Fedora" ]; then
           sudo dnf install $_kernel_rpm $_kernel_devel_rpm
         elif [ "$_distro" = "Suse" ]; then
           sudo zypper install --allow-unsigned-rpm $_kernel_rpm $_kernel_devel_rpm
         fi
-        
-        msg2 "Install successful" 
+
+        msg2 "Install successful"
       fi
     fi
   fi

--- a/install.sh
+++ b/install.sh
@@ -428,12 +428,13 @@ if [ "$1" = "uninstall-help" ]; then
     msg2 "To uninstall a version, you should remove the kernel, kernel-headers and kernel-devel associated to it (if installed), with: "
     msg2 "      sudo dnf remove --noautoremove kernel-VERSION kernel-devel-VERSION kernel-headers-VERSION"
     msg2 "       where VERSION is displayed in the second column"
-     msg2 "Note: kernel-headers packages are no longer created and installed, you can safely remove any remnants."
+    msg2 "Note: kernel-headers packages are no longer created and installed, you can safely remove any remnants."
   elif [ "$_distro" = "Suse" ]; then
     zypper packages --installed-only | grep "kernel.*tkg"
     msg2 "To uninstall a version, you should remove the kernel, kernel-headers and kernel-devel associated to it (if installed), with: "
     msg2 "      sudo zypper remove --no-clean-deps kernel-VERSION kernel-devel-VERSION kernel-headers-VERSION"
     msg2 "       where VERSION is displayed in the second to last column"
+    msg2 "Note: kernel-headers packages are no longer created and installed, you can safely remove any remnants."
   fi
 
 fi


### PR DESCRIPTION
Weirdly enough, I expected the kernel headers to be contained in the `kernel-headers` RPM packages. But they are actually in `kernel-devel`. So obviously that broke DKMS, and now it should be fixed!. Although we are back to using the lenghty `make rpm-pkg`.

I checked what's inside the DEBs and my change should work since `linux-headers` DEB package does actually contain the headers where DKMS wants them.

Closes: #230
Closes: #229