### PR TITLE
prepare: Prevent config prompt w/ modprobed-db.

### DIFF
--- a/customization.cfg
+++ b/customization.cfg
@@ -42,7 +42,6 @@ _force_all_threads="true"
 _noccache="false"
 
 # Set to true to use modprobed db to clean config from unneeded modules. Speeds up compilation considerably. Requires root - https://wiki.archlinux.org/index.php/Modprobed-db
-# Using this option can trigger user prompts if the config doesn't go smoothly.
 # !!!! Make sure to have a well populated db !!!! - Leave empty to be asked about it at build time
 _modprobeddb="false"
 

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -1373,6 +1373,10 @@ CONFIG_DEBUG_INFO_BTF_MODULES=y\n
       msg2 "modprobed-db database not found"
       exit 1
     fi
+    # Workaround for: https://github.com/Tk-Glitch/PKGBUILDS/issues/404.
+    echo "# CONFIG_GPIO_BT8XX is not set" >> ./.config
+    echo "# CONFIG_SND_SE6X is not set" >> ./.config
+    
     make LSMOD=$_modprobeddb_db_path localmodconfig ${llvm_opt}
   fi
 


### PR DESCRIPTION
Seeing as #239 nixed the `yes "" |` solution to Tk-Glitch/PKGBUILDS#404, I looked for another way to prevent the prompts. As @Tk-Glitch mentioned that adding the entries wasn't successful, I was convinced that there is a bug in `make localmodconfig`, and stepped through the Perl script for a few hours.

In the end, though, it seems that adding those two config lines fixes the issue just fine. I still don't really understand why this occurs, but this indeed should be better than piping newline key presses to `make`.