### PR TITLE
Change to new name for Graysky march repository

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -76,7 +76,7 @@ case $_basever in
 	opt_ver="4.19-5.4"
 	source=("$kernel_site"
         	"$patch_site"
-        	"https://raw.githubusercontent.com/graysky2/kernel_gcc_patch/master/more-uarches-for-kernel-4.19-5.4.patch"
+        	"https://raw.githubusercontent.com/graysky2/kernel_compiler_patch/master/more-uarches-for-kernel-4.19-5.4.patch"
         	'config.x86_64' # stock Arch config
         	'config_hardened.x86_64' # hardened Arch config
         	90-cleanup.hook
@@ -127,7 +127,7 @@ case $_basever in
 	opt_ver="5.7"
 	source=("$kernel_site"
         	"$patch_site"
-        	"https://raw.githubusercontent.com/graysky2/kernel_gcc_patch/master/outdated_versions/enable_additional_cpu_optimizations_for_gcc_v10.1%2B_kernel_v5.7.patch"
+        	"https://raw.githubusercontent.com/graysky2/kernel_compiler_patch/master/outdated_versions/enable_additional_cpu_optimizations_for_gcc_v10.1%2B_kernel_v5.7.patch"
         	'config.x86_64' # stock Arch config
         	'config_hardened.x86_64' # hardened Arch config
         	90-cleanup.hook
@@ -181,7 +181,7 @@ case $_basever in
 	opt_ver="5.8%2B"
 	source=("$kernel_site"
         	"$patch_site"
-        	"https://raw.githubusercontent.com/graysky2/kernel_gcc_patch/master/more-uarches-for-kernel-5.8%2B.patch"
+        	"https://raw.githubusercontent.com/graysky2/kernel_compiler_patch/master/more-uarches-for-kernel-5.8%2B.patch"
         	'config.x86_64' # stock Arch config
         	#'config_hardened.x86_64' # hardened Arch config
         	90-cleanup.hook
@@ -232,7 +232,7 @@ case $_basever in
 	opt_ver="5.8%2B"
 	source=("$kernel_site"
         	$patch_site
-		"https://raw.githubusercontent.com/graysky2/kernel_gcc_patch/master/more-uarches-for-kernel-5.8%2B.patch"
+		"https://raw.githubusercontent.com/graysky2/kernel_compiler_patch/master/more-uarches-for-kernel-5.8%2B.patch"
         	"config.x86_64" # stock Arch config
         	#$hardened_config_file # hardened Arch config
         	90-cleanup.hook
@@ -286,7 +286,7 @@ case $_basever in
 	opt_ver="5.8%2B"
     source=("$kernel_site"
         "$patch_site"
-        "https://raw.githubusercontent.com/graysky2/kernel_gcc_patch/master/more-uarches-for-kernel-5.8%2B.patch"
+        "https://raw.githubusercontent.com/graysky2/kernel_compiler_patch/master/more-uarches-for-kernel-5.8%2B.patch"
         'config.x86_64' # stock Arch config
         'config_hardened.x86_64' # hardened Arch config
         90-cleanup.hook
@@ -346,7 +346,7 @@ case $_basever in
 	opt_ver="5.8%2B"
     source=("$kernel_site"
         "$patch_site"
-        "https://raw.githubusercontent.com/graysky2/kernel_gcc_patch/master/more-uarches-for-kernel-5.8%2B.patch"
+        "https://raw.githubusercontent.com/graysky2/kernel_compiler_patch/master/more-uarches-for-kernel-5.8%2B.patch"
         'config.x86_64' # stock Arch config
         'config_hardened.x86_64' # hardened Arch config
         90-cleanup.hook
@@ -413,7 +413,7 @@ case $_basever in
 	opt_ver="5.8%2B"
     source=("$kernel_site"
         "$patch_site"
-        "https://raw.githubusercontent.com/graysky2/kernel_gcc_patch/master/more-uarches-for-kernel-5.8%2B.patch"
+        "https://raw.githubusercontent.com/graysky2/kernel_compiler_patch/master/more-uarches-for-kernel-5.8%2B.patch"
         'config.x86_64' # stock Arch config
         #'config_hardened.x86_64' # hardened Arch config
         90-cleanup.hook
@@ -476,7 +476,7 @@ case $_basever in
 	opt_ver="5.8%2B"
     source=("$kernel_site"
         #"$patch_site"
-        "https://raw.githubusercontent.com/graysky2/kernel_gcc_patch/master/more-uarches-for-kernel-5.8%2B.patch"
+        "https://raw.githubusercontent.com/graysky2/kernel_compiler_patch/master/more-uarches-for-kernel-5.8%2B.patch"
         'config.x86_64' # stock Arch config
         #'config_hardened.x86_64' # hardened Arch config
         90-cleanup.hook

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You're set to run Anbox.
 
 
 ## Other stuff included:
-- Graysky's per-CPU-arch native optimizations - https://github.com/graysky2/kernel_gcc_patch
+- Graysky's per-CPU-arch native optimizations - https://github.com/graysky2/kernel_compiler_patch
 - memory management and swapping tweaks
 - scheduling tweaks
 - optional "Zenify" patchset using core blk, mm and scheduler tweaks from Zen

--- a/install.sh
+++ b/install.sh
@@ -244,9 +244,9 @@ if [ "$1" = "install" ] || [ "$1" = "config" ]; then
   esac
 
   if [ "$opt_alternative_url" != "true" ]; then
-    wget "https://raw.githubusercontent.com/graysky2/kernel_gcc_patch/master/more-uarches-for-kernel-${opt_ver}.patch"
+    wget "https://raw.githubusercontent.com/graysky2/kernel_compiler_patch/master/more-uarches-for-kernel-${opt_ver}.patch"
   else
-    wget "https://raw.githubusercontent.com/graysky2/kernel_gcc_patch/master/outdated_versions/enable_additional_cpu_optimizations_for_gcc_v10.1+_kernel_v${opt_ver}.patch"
+    wget "https://raw.githubusercontent.com/graysky2/kernel_compiler_patch/master/outdated_versions/enable_additional_cpu_optimizations_for_gcc_v10.1+_kernel_v${opt_ver}.patch"
   fi
 
   # Follow Ubuntu install isntructions in https://wiki.ubuntu.com/KernelTeam/GitKernelBuild

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -370,7 +370,7 @@ _tkg_srcprep() {
 
   if [ -z $_debug ]; then
 
-  # graysky's cpu opts - https://github.com/graysky2/kernel_gcc_patch
+  # graysky's cpu opts - https://github.com/graysky2/kernel_compiler_patch
   if [ "${_distro}" = "Arch" ]; then
     tkgpatch="$srcdir/more-uarches-for-kernel-${opt_ver}.patch"
   elif [ "${_distro}" = "Void" ]; then


### PR DESCRIPTION
After [my PR and discussion with Graysky2](https://github.com/graysky2/kernel_compiler_patch/pull/73), he changed the repository's name to `kernel_compiler_patch`. So we need to reflect the changes. I have not tried on Arch but I suppose I didn't miss anything, I changed all the occurrences of the URL.

This closes #259 