### PR TITLE
prepare: restrict user input to digits in _prompt_from_array

### DIFF
--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -63,7 +63,7 @@ _prompt_from_array() {
     if [[ -z "$REPLY" && -n "$_default_index" ]]; then
       _selected_index="$_default_index"
       break
-    elif [[ -n "$REPLY" && 0 -le "$REPLY" && "$REPLY" -le $_N ]]; then
+    elif [[ "$REPLY" =~ ^[0-9]+$ && 0 -le "$REPLY" && "$REPLY" -le $_N ]]; then
       _selected_index="$REPLY"
       break
     else


### PR DESCRIPTION
Hello again!

I discovered that entering any text string to prompts from `_prompt_from_array` in `prepare` actually makes it chose something although it shouldn't and should ask again. This should fix it.

Adel