### PR TITLE
Make vmlinux stripping optional 

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -726,6 +726,7 @@ hackheaders() {
   ln -sr "$builddir" "$pkgdir/usr/src/$pkgbase"
 
   if [ $_STRIP = "true" ]; then
+    echo "Stripping vmlinux..."
     strip -v $STRIP_STATIC "$builddir/vmlinux"
   fi
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -725,8 +725,9 @@ hackheaders() {
   mkdir -p "$pkgdir/usr/src"
   ln -sr "$builddir" "$pkgdir/usr/src/$pkgbase"
 
-  echo "Stripping vmlinux..."
-  strip -v $STRIP_STATIC "$builddir/vmlinux"
+  if [ $_STRIP = "true" ]; then
+    strip -v $STRIP_STATIC "$builddir/vmlinux"
+  fi
 
   if [ $_NUKR = "true" ]; then
     rm -rf "$srcdir" # Nuke the entire src folder so it'll get regenerated clean on next build

--- a/customization.cfg
+++ b/customization.cfg
@@ -77,7 +77,7 @@ _configfile=""
 _debugdisable="false"
 
 # Strip the vmlinux file after build is done. Set to anything other than "true" if you require debug headers. Default is "true" 
-_STRIP=false
+_STRIP="true"
 
 # LEAVE AN EMPTY VALUE TO BE PROMPTED ABOUT FOLLOWING OPTIONS AT BUILD TIME
 

--- a/customization.cfg
+++ b/customization.cfg
@@ -76,6 +76,9 @@ _configfile=""
 # Disable some non-module debugging - See PKGBUILD for the list
 _debugdisable="false"
 
+# Strip the vmlinux file after build is done. Set to anything other than "true" if you require debug headers. Default is "true" 
+_STRIP=false
+
 # LEAVE AN EMPTY VALUE TO BE PROMPTED ABOUT FOLLOWING OPTIONS AT BUILD TIME
 
 # CPU scheduler - Options are "upds" (TkG's Undead PDS), "pds", "bmq", "muqss", "cacule" or "cfs" (kernel's default)


### PR DESCRIPTION
as the title says this just adds the option to not strip the vmlinux file in case you need debug tools like fadd2line 