### PR TITLE
Changes to Anbox instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ systemctl enable anbox-container-manager.service
 ```
 
 You're set to run Anbox.
-
+If you prefer automatic setup you can install `anbox-support` from AUR which will take care of everything by itself.
 
 
 ### Install procedure


### PR DESCRIPTION
I created an `anbox-support` package which takes care of every step needed to get Anbox running without having to do manual changes to the filesystem. -> https://aur.archlinux.org/packages/anbox-support
Also, `anbox-git` recently got some changes - one of them being `/usr/lib/systemd/system/dev-binderfs.mount` being shipped which mounts binderfs without further intervention. It might be good to reflect that in the README as well. 