### PR TITLE
Add 5.14 to allowed versions

### DIFF
--- a/customization.cfg
+++ b/customization.cfg
@@ -5,7 +5,7 @@
 # If left empty, the script will prompt
 _distro=""
 
-# Kernel Version - Options are "5.4", "5.7", "5.8", "5.9", "5.10", "5.11", "5.12", "5.13"
+# Kernel Version - Options are "5.4", "5.7", "5.8", "5.9", "5.10", "5.11", "5.12", "5.13", "5.14"
 _version=""
 
 #### MISC OPTIONS ####


### PR DESCRIPTION
This PR adds 5.14 to the comment above the `_version` option in customization.cfg