### PR TITLE
Unify Ubuntu and Debian dependency installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -37,10 +37,7 @@ _install_dependencies() {
   if [ "$_compiler_name" = "llvm" ]; then
     clang_deps="llvm clang lld"
   fi
-  if [ "$_distro" = "Ubuntu" ]; then
-    msg2 "Installing dependencies"
-    sudo apt install git build-essential fakeroot libncurses5-dev libssl-dev ccache bison flex qtbase5-dev ${clang_deps} -y
-  elif [ "$_distro" = "Debian" ]; then
+  if [ "$_distro" = "Debian" -o "$_distro" = "Ubuntu" ]; then
     msg2 "Installing dependencies"
     sudo apt install git wget build-essential fakeroot libncurses5-dev libssl-dev ccache bison flex qtbase5-dev bc rsync kmod cpio libelf-dev ${clang_deps} -y
   elif [ "$_distro" = "Fedora" ]; then


### PR DESCRIPTION
My KUbuntu installation turned out to lack `libelf-dev`, causing build error. I originally wanted to simply add it to Ubuntu package list, but then noticed that Debian option already includes it.

Since there's no harm in trying to install already installed packages, I've just merged two codepaths to use Debian's more extensive package list.