### PR TITLE
Add schedtool pacakge for fedora

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -46,7 +46,7 @@ _install_dependencies() {
   elif [ "$_distro" = "Fedora" ]; then
     msg2 "Installing dependencies"
     if [ $(rpm -E %fedora) = "32" ]; then
-      sudo dnf install fedpkg fedora-packager rpmdevtools ncurses-devel pesign grubby qt5-devel libXi-devel gcc-c++ git ccache flex bison elfutils-libelf-devel openssl-devel dwarves rpm-build ${clang_deps} -y
+      sudo dnf install fedpkg fedora-packager rpmdevtools ncurses-devel pesign grubby qt5-devel libXi-devel gcc-c++ git ccache flex bison schedtool elfutils-libelf-devel openssl-devel dwarves rpm-build ${clang_deps} -y
     else
       sudo dnf install qt5-qtbase-devel fedpkg fedora-packager rpmdevtools ncurses-devel pesign grubby libXi-devel gcc-c++ git ccache flex bison elfutils-libelf-devel elfutils-devel openssl openssl-devel dwarves rpm-build perl-devel perl-generators python3-devel make -y ${clang_deps} -y
     fi

--- a/install.sh
+++ b/install.sh
@@ -39,20 +39,20 @@ _install_dependencies() {
   fi
   if [ "$_distro" = "Ubuntu" ]; then
     msg2 "Installing dependencies"
-    sudo apt install git build-essential fakeroot libncurses5-dev libssl-dev ccache bison flex qtbase5-dev libelf-dev ${clang_deps} -y
+    sudo apt install git build-essential fakeroot libncurses5-dev libssl-dev ccache bison flex schedtool qtbase5-dev libelf-dev ${clang_deps} -y
   elif [ "$_distro" = "Debian" ]; then
     msg2 "Installing dependencies"
-    sudo apt install git wget build-essential fakeroot libncurses5-dev libssl-dev ccache bison flex qtbase5-dev bc rsync kmod cpio libelf-dev ${clang_deps} -y
+    sudo apt install git wget build-essential fakeroot libncurses5-dev libssl-dev ccache bison flex schedtool qtbase5-dev bc rsync kmod cpio libelf-dev ${clang_deps} -y
   elif [ "$_distro" = "Fedora" ]; then
     msg2 "Installing dependencies"
     if [ $(rpm -E %fedora) = "32" ]; then
       sudo dnf install fedpkg fedora-packager rpmdevtools ncurses-devel pesign grubby qt5-devel libXi-devel gcc-c++ git ccache flex bison schedtool elfutils-libelf-devel openssl-devel dwarves rpm-build ${clang_deps} -y
     else
-      sudo dnf install qt5-qtbase-devel fedpkg fedora-packager rpmdevtools ncurses-devel pesign grubby libXi-devel gcc-c++ git ccache flex bison elfutils-libelf-devel elfutils-devel openssl openssl-devel dwarves rpm-build perl-devel perl-generators python3-devel make -y ${clang_deps} -y
+      sudo dnf install qt5-qtbase-devel fedpkg fedora-packager rpmdevtools ncurses-devel pesign grubby libXi-devel gcc-c++ git ccache flex bison schedtool elfutils-libelf-devel elfutils-devel openssl openssl-devel dwarves rpm-build perl-devel perl-generators python3-devel make -y ${clang_deps} -y
     fi
   elif [ "$_distro" = "Suse" ]; then
     msg2 "Installing dependencies"
-    sudo zypper install -y rpmdevtools ncurses-devel pesign libXi-devel gcc-c++ git ccache flex bison elfutils libelf-devel openssl-devel dwarves make patch bc rpm-build libqt5-qtbase-common-devel libqt5-qtbase-devel lz4 ${clang_deps}
+    sudo zypper install -y rpmdevtools ncurses-devel pesign libXi-devel gcc-c++ git ccache flex bison elfutils libelf-devel openssl-devel dwarves make schedtool patch bc rpm-build libqt5-qtbase-common-devel libqt5-qtbase-devel lz4 ${clang_deps}
   fi
 }
 


### PR DESCRIPTION
Missing the package 'schedtool' on Fedora Linux.
Tested on Fedora 34