### PR TITLE
Add AMD C3 no cache flush patch

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -316,6 +316,7 @@ case $_basever in
         0009-prjc_v5.10-r2.patch
         0012-linux-hardened.patch
         0012-misc-additions.patch
+        0013-amd-c3-no-cache-flush.patch
     )
     sha256sums=('dcdf99e43e98330d925016985bfbc7b83c66d367b714b2de0cbbfcbf83d8ca43'
             '2aba8c5affb9b2012d7ce10d4f65bacc668b5549cb185c53333817e0f5137b19'
@@ -344,7 +345,8 @@ case $_basever in
             'a557b342111849a5f920bbe1c129f3ff1fc1eff62c6bd6685e0972fc88e39911'
             '77e71048389e3e1d6bbdfaf384f62120d3f984257b758d75366c7bebe6be64fa'
             '105f51e904d80f63c1421203e093b612fc724edefd3e388b64f8d371c0b3a842'
-            '7fb1104c167edb79ec8fbdcde97940ed0f806aa978bdd14d0c665a1d76d25c24')
+            '7fb1104c167edb79ec8fbdcde97940ed0f806aa978bdd14d0c665a1d76d25c24'
+            'ad1ddaeb5a13d6c8d47089799db343b8df8fcc11ee12f358057410f303d9ee69')
 	;;
 	511)
 	opt_ver="5.8-5.14"
@@ -567,6 +569,7 @@ case $_basever in
         0009-prjc_v5.14-r2.patch
         #0012-linux-hardened.patch
         0012-misc-additions.patch
+        0013-amd-c3-no-cache-flush.patch
         # MM Dirty Soft for WRITE_WATCH support in Wine
         0001-mm-Support-soft-dirty-flag-reset-for-VA-range.patch
         0002-mm-Support-soft-dirty-flag-read-with-reset.patch
@@ -591,6 +594,7 @@ case $_basever in
             'a557b342111849a5f920bbe1c129f3ff1fc1eff62c6bd6685e0972fc88e39911'
             '42ca7bceade1e6a998eeee394c77e3dd93db45ff0870a5dab22350bd0af45272'
             '1aa0a172e1e27fb8171053f3047dcf4a61bd2eda5ea18f02b2bb391741a69887'
+            'ad1ddaeb5a13d6c8d47089799db343b8df8fcc11ee12f358057410f303d9ee69'
             '1b656ad96004f27e9dc63d7f430b50d5c48510d6d4cd595a81c24b21adb70313'
             'b0319a7dff9c48b2f3e3d3597ee154bf92223149a633a8b7ce4026252db86da6')
 	;;

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -425,6 +425,9 @@ _tkg_srcprep() {
   tkgpatch="$srcdir/0001-mm-Support-soft-dirty-flag-reset-for-VA-range.patch" && _tkg_patcher
   tkgpatch="$srcdir/0002-mm-Support-soft-dirty-flag-read-with-reset.patch" && _tkg_patcher
 
+  _msg="Applying AMD C3 no cache flush patch (Intel CPUs are not affected)"
+  tkgpatch="$srcdir/0013-amd-c3-no-cache-flush.patch" && _tkg_patcher
+
   # prjc/bmq patch rev
   if [ "$_basever" = "58" ] || [ "$_basever" = "57" ]; then
     rev=3

--- a/linux-tkg-patches/5.10/0013-amd-c3-no-cache-flush.patch
+++ b/linux-tkg-patches/5.10/0013-amd-c3-no-cache-flush.patch
@@ -1,0 +1,55 @@
+https://lore.kernel.org/lkml/20210819004305.20203-1-deepak.sharma@amd.com/
+
+From: Deepak Sharma <deepak.sharma@amd.com>
+To: <deepak.sharma@amd.com>
+Cc: "Rafael J. Wysocki" <rjw@rjwysocki.net>,
+	Len Brown <len.brown@intel.com>, Pavel Machek <pavel@ucw.cz>,
+	Thomas Gleixner <tglx@linutronix.de>,
+	"Ingo Molnar" <mingo@redhat.com>, Borislav Petkov <bp@alien8.de>,
+	"maintainer:X86 ARCHITECTURE (32-BIT AND 64-BIT)"
+	<x86@kernel.org>, "H. Peter Anvin" <hpa@zytor.com>,
+	"open list:SUSPEND TO RAM" <linux-pm@vger.kernel.org>,
+	"open list:X86 ARCHITECTURE (32-BIT AND 64-BIT)" 
+	<linux-kernel@vger.kernel.org>
+Subject: [PATCH] x86/ACPI/State: Optimize C3 entry on AMD CPUs
+Date: Wed, 18 Aug 2021 17:43:05 -0700
+Message-ID: <20210819004305.20203-1-deepak.sharma@amd.com> (raw)
+
+AMD CPU which support C3 shares cache. Its not necessary to flush the
+caches in software before entering C3. This will cause performance drop
+for the cores which share some caches. ARB_DIS is not used with current
+AMD C state implementation. So set related flags correctly.
+
+Signed-off-by: Deepak Sharma <deepak.sharma@amd.com>
+---
+ arch/x86/kernel/acpi/cstate.c | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/arch/x86/kernel/acpi/cstate.c b/arch/x86/kernel/acpi/cstate.c
+index 7de599eba7f0..62a5986d625a 100644
+--- a/arch/x86/kernel/acpi/cstate.c
++++ b/arch/x86/kernel/acpi/cstate.c
+@@ -79,6 +79,21 @@ void acpi_processor_power_init_bm_check(struct acpi_processor_flags *flags,
+ 		 */
+ 		flags->bm_control = 0;
+ 	}
++	if (c->x86_vendor == X86_VENDOR_AMD) {
++		/*
++		 * For all AMD CPUs that support C3, caches should not be
++		 * flushed by software while entering C3 type state. Set
++		 * bm->check to 1 so that kernel doesn't need to execute
++		 * cache flush operation.
++		 */
++		flags->bm_check = 1;
++		/*
++		 * In current AMD C state implementation ARB_DIS is no longer
++		 * used. So set bm_control to zero to indicate ARB_DIS is not
++		 * required while entering C3 type state.
++		 */
++		flags->bm_control = 0;
++	}
+ }
+ EXPORT_SYMBOL(acpi_processor_power_init_bm_check);
+ 
+-- 
+2.25.1

--- a/linux-tkg-patches/5.14/0013-amd-c3-no-cache-flush.patch
+++ b/linux-tkg-patches/5.14/0013-amd-c3-no-cache-flush.patch
@@ -1,0 +1,55 @@
+https://lore.kernel.org/lkml/20210819004305.20203-1-deepak.sharma@amd.com/
+
+From: Deepak Sharma <deepak.sharma@amd.com>
+To: <deepak.sharma@amd.com>
+Cc: "Rafael J. Wysocki" <rjw@rjwysocki.net>,
+	Len Brown <len.brown@intel.com>, Pavel Machek <pavel@ucw.cz>,
+	Thomas Gleixner <tglx@linutronix.de>,
+	"Ingo Molnar" <mingo@redhat.com>, Borislav Petkov <bp@alien8.de>,
+	"maintainer:X86 ARCHITECTURE (32-BIT AND 64-BIT)"
+	<x86@kernel.org>, "H. Peter Anvin" <hpa@zytor.com>,
+	"open list:SUSPEND TO RAM" <linux-pm@vger.kernel.org>,
+	"open list:X86 ARCHITECTURE (32-BIT AND 64-BIT)" 
+	<linux-kernel@vger.kernel.org>
+Subject: [PATCH] x86/ACPI/State: Optimize C3 entry on AMD CPUs
+Date: Wed, 18 Aug 2021 17:43:05 -0700
+Message-ID: <20210819004305.20203-1-deepak.sharma@amd.com> (raw)
+
+AMD CPU which support C3 shares cache. Its not necessary to flush the
+caches in software before entering C3. This will cause performance drop
+for the cores which share some caches. ARB_DIS is not used with current
+AMD C state implementation. So set related flags correctly.
+
+Signed-off-by: Deepak Sharma <deepak.sharma@amd.com>
+---
+ arch/x86/kernel/acpi/cstate.c | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/arch/x86/kernel/acpi/cstate.c b/arch/x86/kernel/acpi/cstate.c
+index 7de599eba7f0..62a5986d625a 100644
+--- a/arch/x86/kernel/acpi/cstate.c
++++ b/arch/x86/kernel/acpi/cstate.c
+@@ -79,6 +79,21 @@ void acpi_processor_power_init_bm_check(struct acpi_processor_flags *flags,
+ 		 */
+ 		flags->bm_control = 0;
+ 	}
++	if (c->x86_vendor == X86_VENDOR_AMD) {
++		/*
++		 * For all AMD CPUs that support C3, caches should not be
++		 * flushed by software while entering C3 type state. Set
++		 * bm->check to 1 so that kernel doesn't need to execute
++		 * cache flush operation.
++		 */
++		flags->bm_check = 1;
++		/*
++		 * In current AMD C state implementation ARB_DIS is no longer
++		 * used. So set bm_control to zero to indicate ARB_DIS is not
++		 * required while entering C3 type state.
++		 */
++		flags->bm_control = 0;
++	}
+ }
+ EXPORT_SYMBOL(acpi_processor_power_init_bm_check);
+ 
+-- 
+2.25.1


### PR DESCRIPTION
Just a little patch to apply by default the patch that is specific to AMD CPUs to not flush the cache when entering C3 state.

I did not test the change in PKGBUILD, but it should work x) Otherwise please feel free to make the small fixes yourself to go faster :P