### PR TITLE
Fix boot issues in Ubuntu (and potentially Debian)

### DIFF
--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -1302,6 +1302,14 @@ CONFIG_DEBUG_INFO_BTF_MODULES=y\r
     fi
   fi
 
+  # Distro specific workarounds in the .config file, when using Arch config file by default
+  if [ -z  "$_configfile" ] || [ "$_configfile" = "config_hardened.x86_64" ]; then
+    if [[ "$_distro" =~ ^(Debian|Ubuntu)$ ]]; then
+      _disable "MODULE_COMPRESS_ZSTD"
+      _enable "MODULE_COMPRESS_NONE"
+    fi
+  fi
+
   # set _menuconfig early for Void
   if [ "$_distro" = "Void" ]; then
     _menuconfig="Void"


### PR DESCRIPTION
Thanks to @cpw the boot issues reported in Ubuntu have been figured out!

The issue was that Ubuntu's initramfs generation tool doesn't play nice with zstd compressed modules... Who knew. The fix also involves Debian, although I don't know if it's the same tool or not.

Adel

Closes: #327
Closes: #322