### PR TITLE
README: Gentoo: remove inaccurate dependency on a Clang use flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,6 @@ cd linux-tkg
 ./install.sh install
 ```
 **Notes:**
-- To compile with `clang` with this script, you need to have the `default-compiler-rt` `USE` flag for `sys-devel/clang`.
 - The script will prompt for using `llvm-libunwind`, it can only work with the `llvm-libunwind` `USE` flag in `sys-devel/clang` but it is experimental:
   - Manual intervention is needed on the `net-fs/samba` EBUILD, see [here](https://bugs.gentoo.org/791349)
   - The `-unwind` `USE` flag is needed in `app-emulation/wine*` EBUILDs


### PR DESCRIPTION
I tested the USE flag change from #323 and in the end it's not needed as I could successfully compile without the `default-compiler-rt` USE flag. 