### PR TITLE
prepare: disable GCC_PLUGINS by default

### DIFF
--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -667,12 +667,8 @@ CONFIG_DEBUG_INFO_BTF_MODULES=y\r
   _module "I2C_NCT6775"
 
   # ccache fix
-  if [ "$_noccache" != "true" ]; then
-    if { [ "$_distro" = "Arch" ] && pacman -Qq ccache &> /dev/null; } || { [ "$_distro" = "Ubuntu" ] && dpkg -l ccache > /dev/null; }\
-	    || { [ "$_distro" = "Void" ] && xbps-query -s ccache > /dev/null; } ; then
-      _disable "GCC_PLUGINS"
-    fi
-  fi
+  _disable "GCC_PLUGINS"
+
   # Clang LTO
   if [ "$_compiler_name" = "-llvm" ] && [ $_basever -ge 512 ]; then
     if [ "$_lto_mode" = "full" ]; then


### PR DESCRIPTION
Hello,

From what I am seeing about the use of `GCC_PLUGINS` [here](https://www.kernel.org/doc/html/v5.15-rc2/kbuild/gcc-plugins.html) it is not even worth having it enabled. 

What do you think ?