### PR TITLE
Correct applying fsyncs patches on kernels 5.12 and below

### DIFF
--- a/customization.cfg
+++ b/customization.cfg
@@ -148,7 +148,7 @@ _acs_override=""
 _bcachefs=""
 
 # Set to "true" to enable support for fsync, an experimental replacement for esync found in Valve Proton 4.11+ - https://steamcommunity.com/games/221410/announcements/detail/2957094910196249305
-# Can be enabled alongside _futex_waitv on 5.14+ to use it as a fallback for older Proton builds
+# Can be enabled alongside _futex_waitv on 5.13+ to use it as a fallback for older Proton builds
 _fsync="true"
 
 # Set to "true" to enable support for futex2, an experimental interface that can be used by proton-tkg and proton 5.13 experimental through Fsync - Can be enabled alongside fsync to use it as a fallback

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -1078,6 +1078,8 @@ _tkg_srcprep() {
       _tkg_patcher
       _futex2="false"
     fi
+  else
+    _futex_waitv="false"
   fi
 
   # fsync support
@@ -1120,7 +1122,8 @@ _tkg_srcprep() {
     fi
   fi
 
-  if [ "$_futex2" = "true" ] && [ "$_futex_waitv" != "true" ] && [ "$_basever" != "54" ] && [ "$_basever" != "57" ] && [ "$_basever" != "58" ] && [ "$_basever" != "59" ]; then
+  if ( [ "$_futex2" = "true" ] && [ -e "$srcdir/0007-v${_basekernel}-futex2_interface.patch" ] ) \
+    && ( [ "$_futex_waitv" != "true" ] && [ -e "$srcdir/0007-v${_basekernel}-futex_waitv.patch" ] ); then
     sed -i -e 's/# CONFIG_EXPERT is not set/CONFIG_EXPERT=y/' ./.config
     echo -e "\r# start of config expert\r
 # CONFIG_DEBUG_RSEQ is not set\r


### PR DESCRIPTION
it looks like there won't be any futex-waitv backports for more older kernels anytime soon, so need to fix the patching behavior of previously existing patches.