### PR TITLE
prepare: Fix and Cleanup some unnecessary checks related to Futex2

### DIFF
--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -1122,8 +1122,7 @@ _tkg_srcprep() {
     fi
   fi
 
-  if ( [ "$_futex2" = "true" ] && [ -e "$srcdir/0007-v${_basekernel}-futex2_interface.patch" ] ) \
-    && ( [ "$_futex_waitv" != "true" ] && [ -e "$srcdir/0007-v${_basekernel}-futex_waitv.patch" ] ); then
+  if [ "$_futex2" = "true" ] && [ -e "$srcdir/0007-v${_basekernel}-futex2_interface.patch" ]; then
     sed -i -e 's/# CONFIG_EXPERT is not set/CONFIG_EXPERT=y/' ./.config
     echo -e "\r# start of config expert\r
 # CONFIG_DEBUG_RSEQ is not set\r


### PR DESCRIPTION
Sorry, it looks like this check does not work properly,
but all these checks can be omitted due to 3462554540a75f346bd65a73ecd458fbfe21da29 in which the behavior of the script has changed.
This way it will simplify the script and fix the problem at the same time.