### PR TITLE
set LTO_NONE=y/n according to _lto_mode choice

### DIFF
--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -590,9 +590,15 @@ _tkg_srcprep() {
     if [ "$_lto_mode" = "full" ]; then
       _enable LTO_CLANG_FULL
       _disable LTO_CLANG_THIN
+      _disable LTO_NONE
     elif [ "$_lto_mode" = "thin" ]; then
       _disable LTO_CLANG_FULL
       _enable LTO_CLANG_THIN
+      _disable LTO_NONE
+    else
+      _disable LTO_CLANG_FULL
+      _disable LTO_CLANG_THIN
+      _enable LTO_NONE
     fi
   fi
   # Void uses LibreSSL


### PR DESCRIPTION
fixes #371

Kernel (5.15.5) builds and boots (on Fedora 35, using `_lto_mode="full"`).