### PR TITLE
Fix resolve_btfids fix

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -858,9 +858,9 @@ hackheaders() {
   # add resolve_btfids on 5.16
   case $_basever in
     516)
+        install -Dt "$builddir"/tools/bpf/resolve_btfids tools/bpf/resolve_btfids/resolve_btfids
     ;;
     *)
-      install -Dt "$builddir/tools/bpf/resolve_btfids" tools/bpf/resolve_btfids/resolve_btfids
     ;;
   esac
 


### PR DESCRIPTION
So the resolve_btfids fix for DKMS modules in 5.16 was broken, it just didn't work. Both I and flgx on Discord confirmed it. I tried every way I could imagine to tweak just that line, so then I wrote an if-then like:

```
if [[ $_basever == 516 ]]; then
  install -Dt "$builddir/tools/bpf/resolve_btfids" tools/bpf/resolve_btfids/resolve_btfids
fi
```
And that worked, but it was bothering me that your case statement wasn't working. After some tweaking I figured out it was int he wrong place. 

```
  # add resolve_btfids on 5.16
  case $_basever in
    516)
    ;;
    *)
      install -Dt "$builddir/tools/bpf/resolve_btfids" tools/bpf/resolve_btfids/resolve_btfids
    ;;
  esac
```

Leads to it not doing anything at all. I confirmed this with `-Dvt` and there is no installing of anything. It' needs to be in the `516)` array. So I did that. And now it does work, the files are installed into the `$pkgdir` correctly, and DKMS modules **do** install. Hooray! :frog: 