### PR TITLE
Add support for RT patches

### DIFF
--- a/customization.cfg
+++ b/customization.cfg
@@ -105,7 +105,7 @@ _llvm_ias=""
 _lto_mode=""
 
 # Apply PREEMPT_RT patchset to the kernel.
-# ! Other CPU schedulers might not be compatible with this patchset !
+# ! Only CFS CPU scheduler is compatible with this patchset !
 # Set to "1" to enable.
 _preempt_rt=""
 

--- a/customization.cfg
+++ b/customization.cfg
@@ -104,6 +104,16 @@ _llvm_ias=""
 # "thin: uses multiple threads, faster and uses less memory, may have a lower runtime performance than Full."
 _lto_mode=""
 
+# Apply PREEMPT_RT patchset to the kernel.
+# ! Other CPU schedulers might not be compatible with this patchset !
+# Set to "1" to enable.
+_preempt_rt=""
+
+# Forcibly apply the PREEMPT_RT patchset to the kernel, even when upstream does not officially support the kernel subversion.
+# ! This will still not apply when the patch itself or linux-tkg (see _version) do not support the kernel major version - Not recommended !
+# Set to "1" to enable.
+_preempt_rt_force=""
+
 # CPU sched_yield_type - Choose what sort of yield sched_yield will perform
 # For PDS and MuQSS: 0: No yield. (Recommended option for gaming on PDS and MuQSS)
 #                    1: Yield only to better priority/deadline tasks. (Default - can be unstable with PDS on some platforms)

--- a/install.sh
+++ b/install.sh
@@ -314,7 +314,11 @@ if [ "$1" = "install" ]; then
   fi
 
   if [ -z $_kernel_localversion ]; then
-    _kernel_flavor="tkg-${_cpusched}${_compiler_name}"
+    if [ "$_preempt_rt" = "1" ]; then
+      _kernel_flavor="tkg-${_cpusched}-rt${_compiler_name}"
+    else
+      _kernel_flavor="tkg-${_cpusched}${_compiler_name}"
+    fi
   else
     _kernel_flavor="tkg-${_kernel_localversion}"
   fi

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -3,7 +3,7 @@
 # Needed for prompting with the correct order
 _supported_kernels=("5.16" "5.15" "5.14" "5.13" "5.12" "5.11" "5.10" "5.9" "5.8" "5.7" "5.4")
 
-typeset -A _kver_subver_map
+typeset -Ag _kver_subver_map
 _kver_subver_map=(
   ["5.4"]="163"
   ["5.7"]="19"
@@ -16,6 +16,29 @@ _kver_subver_map=(
   ["5.14"]="21"
   ["5.15"]="6"
   ["5.16"]="rc3"
+)
+
+# PREEMPT_RT's supported kernel subversion
+typeset -Ag _rt_subver_map
+_rt_subver_map=(
+  ["5.4"]="161"
+  ["5.9"]="1"
+  ["5.10"]="83"
+  ["5.11"]="4"
+  ["5.14"]="2"
+  ["5.15"]="5"
+)
+
+# PREEMPT_RT's patch revision for the kernel
+# We separated this to allow for forcing the application of the patch when _preempt_rt_force=1 on version mismatch
+typeset -Ag _rt_rev_map
+_rt_rev_map=(
+  ["5.4"]="66"
+  ["5.9"]="20"
+  ["5.10"]="58"
+  ["5.11"]="11"
+  ["5.14"]="21"
+  ["5.15"]="22"
 )
 
 _undefine() {
@@ -392,6 +415,29 @@ _tkg_srcprep() {
     tkgpatch="$srcdir/enable_additional_cpu_optimizations_for_gcc_v10.1+_kernel_v${opt_ver}+.patch"
   fi
   _msg="Applying graysky's cpu opts patch (legacy)" && _tkg_patcher
+
+  # PREEMPT_RT patch
+  if [ "${_preempt_rt}" = "1" ]; then
+    if [ ${_rt_subver_map[$_basekernel]+_} = "_" ]; then
+      preempt_rt_ksubver="${_rt_subver_map[$_basekernel]}"
+      # Check if subversion is supported, skip check if forced
+      if [ "${_preempt_rt_force}" = "1" ] || [ "${preempt_rt_ksubver}" = "${_kver_subver_map[$_basekernel]}" ]; then
+        preempt_rt_file_gz="patch-${_basekernel}.${preempt_rt_ksubver}-rt${_rt_rev_map["$_basekernel"]}.patch.gz"
+        preempt_rt_file=`basename ${preempt_rt_file_gz} .gz`
+        wget -P "$srcdir" "https://cdn.kernel.org/pub/linux/kernel/projects/rt/${_basekernel}/${preempt_rt_file_gz}"
+        last_pwd=`pwd`
+        cd "$srcdir"
+        gunzip -k "$srcdir/${preempt_rt_file_gz}"
+        cd "$last_pwd"
+        tkgpatch="$srcdir/${preempt_rt_file}"
+        _msg="Applying PREEMPT_RT patch" && _tkg_patcher
+      else
+        msg2 "Skipping PREEMPT_RT patch for ${_basekernel}.${_sub}"
+      fi
+    else
+      msg2 "Skipping PREEMPT_RT patch on unsupported kernel version"
+    fi
+  fi
 
   # TkG
   tkgpatch="$srcdir/0002-clear-patches.patch"

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -164,6 +164,10 @@ _set_cpu_scheduler() {
     _avail_cpu_scheds=("cfs")
   fi
 
+  if [ "${_preempt_rt}" = "1" ]; then
+    _avail_cpu_scheds=("cfs")
+  fi
+
   # Populate descriptions of the available CPU schedulers
   _avail_cpu_scheds_text=()
   for _sched in "${_avail_cpu_scheds[@]}"; do


### PR DESCRIPTION
- Resolves #264 

## Changes

 - Added `_preempt_rt` option.
 - Added `_preempt_rt_force` option.
 - Changed some `typeset` variables into globals.

This PR pulls the patches from [upstream RT](https://cdn.kernel.org/pub/linux/kernel/projects/rt/) and then applies them as early as possible. There are checks to see if upstream supports the kernel version being compiled and the check for kernel subversion can be bypassed with `_preempt_rt_force=1`.

To maintain the new feature, updating the entries in `_rt_subver_map` and `_rt_rev_map` will be enough for most cases.