### PR TITLE
Fix CacULE 5.15+ and CacULE link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repository provides scripts to automatically download, patch and compile th
 Alternative schedulers are available to you in linux-tkg:
 - Project C / PDS & BMQ by Alfred Chen: [blog](http://cchalpha.blogspot.com/ ), [code repository](https://gitlab.com/alfredchen/projectc)
 - MuQSS by Con Kolivas : [blog](http://ck-hack.blogspot.com/), [code repository](https://github.com/ckolivas/linux)
-- CacULE by Hamad Marri: [code repository](https://github.com/hamadmarri/cacule-cpu-scheduler)
+- CacULE by Hamad Marri and the CachyOS team: [code repository](https://github.com/CachyOS/cacule-cpu-scheduler)
 - Undead PDS: TkG's port of the pre-Project C "PDS-mq" scheduler by Alfred Chen. While PDS-mq got dropped with kernel 5.1 in favor of its BMQ evolution/rework, it wasn't on par with PDS-mq in gaming. "U" PDS still performs better in some cases than other schedulers, so it's been kept undead.
 
 These alternative schedulers can offer a better performance/latency ratio for gaming and desktop use. The availability of each scheduler depends on the chosen Kernel version: the script will display what's available on a per-version basis.

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -553,6 +553,8 @@ _tkg_srcprep() {
     if [ "${_distro}" = "Void" ]; then
       if [[ $_basever < 515 ]]; then
         wget -P "$wrksrc" "https://raw.githubusercontent.com/hamadmarri/cacule-cpu-scheduler/master/patches/CacULE/v${_basekernel}/cacule-${_basekernel}.patch"
+      elif (($_basever > 515 && $_basever <= 517 )); then
+        wget -P "$wrksrc" "https://raw.githubusercontent.com/CachyOS/cacule-cpu-scheduler/master/patches/CacULE/v${_basekernel}/0001-cacULE-${_basekernel}-full.patch"      
       else
         wget -P "$wrksrc" "https://raw.githubusercontent.com/CachyOS/cacule-cpu-scheduler/master/patches/CacULE/v${_basekernel}/cacule-${_basekernel}.patch"
       fi
@@ -560,6 +562,8 @@ _tkg_srcprep() {
     else
       if [[ $_basever < 515 ]]; then
         wget -P "$srcdir" "https://raw.githubusercontent.com/hamadmarri/cacule-cpu-scheduler/master/patches/CacULE/v${_basekernel}/cacule-${_basekernel}.patch"
+      elif (($_basever > 515 && $_basever <= 517 )); then
+        wget -P "$wrksrc" "https://raw.githubusercontent.com/CachyOS/cacule-cpu-scheduler/master/patches/CacULE/v${_basekernel}/0001-cacULE-${_basekernel}-full.patch"      
       else
         wget -P "$srcdir" "https://raw.githubusercontent.com/CachyOS/cacule-cpu-scheduler/master/patches/CacULE/v${_basekernel}/cacule-${_basekernel}.patch"
       fi

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -162,9 +162,9 @@ _set_cpu_scheduler() {
   elif [ "$_basever" = "515" ]; then
     _avail_cpu_scheds=("pds" "bmq" "cacule" "cfs")
   elif [ "$_basever" = "516" ]; then
-    _avail_cpu_scheds=("pds" "bmq" "cfs")
+    _avail_cpu_scheds=("pds" "bmq" "cacule" "cfs")
   elif [ "$_basever" = "517" ]; then
-    _avail_cpu_scheds=("pds" "bmq" "cfs")
+    _avail_cpu_scheds=("pds" "bmq" "cacule" "cfs")
   else
     _avail_cpu_scheds=("cfs")
   fi


### PR DESCRIPTION
Hi, 
In this pull request I updated linux-tkg/linux-tkg-config/prepare to make CacULE available on 5.16 and 5.17. A few lines in prepare will need to be updated as CacULE releases patches for newer kernels, there may be a better way to do this.

I also updated line 21 in the README to properly link people to the new CacULE repository. In Issue #410, ptr1337 stated that the original creator of CacULE is working on patches there so there does not appear to be a need to also link the original repository.  (I can remove this change from the pull request if requested.)