### PR TITLE
fix cacULE 5.16+ patch file name

### DIFF
--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -556,7 +556,7 @@ _tkg_srcprep() {
       elif [[ $_basever = 515 ]]; then
         wget -P "$wrksrc" "https://raw.githubusercontent.com/CachyOS/cacule-cpu-scheduler/master/patches/CacULE/v${_basekernel}/cacule-${_basekernel}.patch"
       else
-        wget -P "$wrksrc" "https://raw.githubusercontent.com/CachyOS/cacule-cpu-scheduler/master/patches/CacULE/v${_basekernel}/0001-cacULE-${_basekernel}-full.patch"
+        wget -P "$wrksrc" "https://raw.githubusercontent.com/CachyOS/cacule-cpu-scheduler/master/patches/CacULE/v${_basekernel}/0001-cacULE-${_basekernel}.patch"
       fi
       tkgpatch="$wrksrc/cacule-${_basekernel}.patch" && _tkg_patcher
     else
@@ -565,10 +565,10 @@ _tkg_srcprep() {
       elif [[ $_basever = 515 ]]; then
         wget -P "$srcdir" "https://raw.githubusercontent.com/CachyOS/cacule-cpu-scheduler/master/patches/CacULE/v${_basekernel}/cacule-${_basekernel}.patch"
       else
-        wget -P "$srcdir" "https://raw.githubusercontent.com/CachyOS/cacule-cpu-scheduler/master/patches/CacULE/v${_basekernel}/0001-cacULE-${_basekernel}-full.patch"
+        wget -P "$srcdir" "https://raw.githubusercontent.com/CachyOS/cacule-cpu-scheduler/master/patches/CacULE/v${_basekernel}/0001-cacULE-${_basekernel}.patch"
       fi
       tkgpatch="$srcdir/cacule-${_basekernel}.patch" && _tkg_patcher
-      tkgpatch="$srcdir/0001-cacULE-${_basekernel}-full.patch" && _tkg_patcher
+      tkgpatch="$srcdir/0001-cacULE-${_basekernel}.patch" && _tkg_patcher
     fi
     _msg="Applying Glitched CFS patch"
     tkgpatch="$srcdir/0003-glitched-cfs.patch" && _tkg_patcher


### PR DESCRIPTION
remove "-full" from end as it doesn't seem to be present anymore (wasn't ever for 5.17 and recently changed for 5.16 too)
https://github.com/CachyOS/cacule-cpu-scheduler/commit/c28a7acf306a9d7ebcb2adb124acce6fb585ce0d