### PR TITLE
Implement Github workflow to automatically bump kernel versions

### DIFF
--- a/.github/workflows/auto-update-kernel-versions.yml
+++ b/.github/workflows/auto-update-kernel-versions.yml
@@ -1,0 +1,21 @@
+name: Automatic version bumping
+on:
+  schedule:
+    - cron: '3 */6 * * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          git config user.name "BIG UGLY FROGMINER"
+          git config user.email BIG_UGLY_FROGMINER@froggi.es
+          ./update-kernel-versions.sh
+          changes=$(cat kernel_updates)
+          if [ -n "$changes" ]; then
+            git add PKGBUILD linux-tkg-config/prepare
+            git commit --author="Adel KARA SLIMANE <adel.ks@zegrapher.com>" -m "version bumps:$changes"
+            git push
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*
+!.github
 !.gitignore
 *~
 *.orig

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -750,7 +750,7 @@ case $_basever in
         0002-mm-Support-soft-dirty-flag-read-with-reset.patch
     )
     sha256sums=('21b7b7d87dab777dc0e27de99bd167797b774be08b594f384839e54fd62cc217'
-            #'9ff97f3a01ec8744863ff611315c44c1f5d1ff551769f7d8359c85561dee1b1d'
+            #upcoming_kernel_patch_sha256
             'SKIP'
             '961c380f74b9e28a47a21001fc330460dcd639f7580b7a178472e40af8f4dcd4'
             '1e15fc2ef3fa770217ecc63a220e5df2ddbcf3295eb4a021171e7edd4c6cc898'

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# This list includes the currently maintained kernels upstream
-# and always ends with an entry that refers to end of life kernel versions
+# List of kernels that are maintained upstream
 _current_kernels=("5.17" "5.16" "5.15" "5.10" "5.4")
 
 # List of kernels that are no longer maintained upstream

--- a/update-kernel-versions.sh
+++ b/update-kernel-versions.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+
+msg2() {
+ echo -e " \033[1;34m->\033[1;0m \033[1;1m$1\033[1;0m" >&2
+}
+
+escape() {
+  _escaped=$(printf '%s\n' "$1" | sed -e 's/[]\/$*.^[]/\\&/g')
+}
+
+kernel_tags=$(git -c 'versionsort.suffix=-' \
+    ls-remote --exit-code --refs --sort='version:refname' --tags https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git '*.*' \
+    | cut --delimiter='/' --fields=3)
+
+source linux-tkg-config/prepare
+
+updates=""
+for _key in "${_current_kernels[@]}"; do
+  latest_full_ver=$(echo "$kernel_tags" | grep -F "v$_key" | tail -1 | cut -c2-)
+
+  _from_rc_to_release="false"
+  if [[ "${_kver_subver_map[$_key]}" == rc* ]]; then
+    if [[ "$latest_full_ver" == *rc* ]]; then
+      latest_subver="${latest_full_ver##*-rc}"
+    else
+      _from_rc_to_release="true"
+      if [ "$latest_full_ver" = "$_key "]; then
+        # this is the first release after rc, so the kernel version will be 5.xx (and not 5.xx.0)
+        latest_subver="0"
+      else
+        # For whatever reason we are moving from an rc kernel to 5.xx.y
+        latest_subver="${latest_full_ver##*.}"
+      fi
+    fi
+
+    current_subver="${_kver_subver_map[$_key]}"
+    current_subver="${current_subver##*rc}"
+  else
+    if [ "$latest_full_ver" != "$_key" ]; then
+      latest_subver="${latest_full_ver##*.}"
+    else
+      latest_subver="0"
+    fi
+    current_subver=${_kver_subver_map[$_key]}
+  fi
+
+  echo "current version on repository $_key.${_kver_subver_map[$_key]} -> $current_subver"
+  echo "upstream version $latest_full_ver -> $latest_subver"
+
+  old_kernel_shasum=""
+  new_kernel_shasum=""
+
+  old_kernel_patch_shasum=""
+  new_kernel_patch_shasum=""
+
+  if [ "$_from_rc_to_release" = "true" ]; then
+    # append kernel version update to updates
+    updates="${updates} ${latest_full_ver}"
+
+    echo "Updating from rc kernel to release in linux-tkg-config/prepare"
+
+    escape "[\"${_key}\"]=\"rc${current_subver}\""
+    _from="$_escaped"
+
+    escape "[\"${_key}\"]=\"${latest_subver}\""
+    _to="$_escaped"
+
+    sed -i "/^_kver_subver_map=($/,/^)$/s|$_from|$_to|g" linux-tkg-config/prepare
+
+    old_kernel_shasum=$(curl -sL https://git.kernel.org/torvalds/t/linux-${_key}-rc${current_subver}.tar.gz | sha256sum | cut -d' ' -f1)
+    new_kernel_shasum=$(curl -sL https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-${_key}.tar.xz | sha256sum | cut -d' ' -f1)
+
+    if [ "$latest_subver" != "0" ]; then
+      # we move from an rc release directly to a kernel with a subversion update
+      sed -i "s|#\"\$patch_site\"|\"\$patch_site\"|g" PKGBUILD
+      old_kernel_patch_shasum="#upcoming_kernel_patch_sha256"
+      new_kernel_patch_shasum="'$(curl -sL https://cdn.kernel.org/pub/linux/kernel/v5.x/patch-${_key}.${latest_subver}.xz | sha256sum | cut -d' ' -f1)'"
+    fi
+  elif (( "$current_subver" < "$latest_subver" )); then
+    # append kernel version update to updates
+    updates="${updates} ${latest_full_ver}"
+
+    echo "Newer upstream"
+    if [[ "${_kver_subver_map[$_key]}" == rc* ]]; then
+      echo "Updating rc kernel version in linux-tkg-config/prepare"
+
+      escape "[\"${_key}\"]=\"rc${current_subver}\""
+      _from="$_escaped"
+
+      escape "[\"${_key}\"]=\"rc${latest_subver}\""
+      _to="$_escaped"
+
+      sed -i "/^_kver_subver_map=($/,/^)$/s|$_from|$_to|g" linux-tkg-config/prepare
+
+      old_kernel_shasum=$(curl -sL https://git.kernel.org/torvalds/t/linux-${_key}-rc${current_subver}.tar.gz | sha256sum | cut -d' ' -f1)
+      new_kernel_shasum=$(curl -sL https://git.kernel.org/torvalds/t/linux-${_key}-rc${latest_subver}.tar.gz | sha256sum | cut -d' ' -f1)
+    else
+      echo "Updating kernel version in linux-tkg-config/prepare"
+
+      escape "[\"${_key}\"]=\"${current_subver}\""
+      _from="$_escaped"
+
+      escape "[\"${_key}\"]=\"${latest_subver}\""
+      _to="$_escaped"
+
+      sed -i "/^_kver_subver_map=($/,/^)$/s|$_from|$_to|g" linux-tkg-config/prepare
+
+      if [ "$current_subver" = "0" ]; then
+        # we move from an initial release to a kernel subversion update
+        sed -i "s|#\"\$patch_site\"|\"\$patch_site\"|g" PKGBUILD
+        old_kernel_patch_shasum="#upcoming_kernel_patch_sha256"
+        new_kernel_patch_shasum="'$(curl -sL https://cdn.kernel.org/pub/linux/kernel/v5.x/patch-${_key}.${latest_subver}.xz | sha256sum | cut -d' ' -f1)'"
+      else
+        old_kernel_patch_shasum="$(curl -sL https://cdn.kernel.org/pub/linux/kernel/v5.x/patch-${_key}.${current_subver}.xz | sha256sum | cut -d' ' -f1)"
+        new_kernel_patch_shasum="$(curl -sL https://cdn.kernel.org/pub/linux/kernel/v5.x/patch-${_key}.${latest_subver}.xz | sha256sum | cut -d' ' -f1)"
+      fi
+    fi
+  else
+    echo "Same upstream"
+  fi
+
+  if [ -n "$new_kernel_shasum" ]; then
+    sed -i "s|$old_kernel_shasum|$new_kernel_shasum|g" PKGBUILD
+  fi
+
+  if [ -n "$new_kernel_patch_shasum" ]; then
+    sed -i "s|$old_kernel_patch_shasum|$new_kernel_patch_shasum|g" PKGBUILD
+  fi
+
+  echo "----------------------"
+done
+
+echo "$updates" > kernel_updates

--- a/update-kernel-versions.sh
+++ b/update-kernel-versions.sh
@@ -120,10 +120,12 @@ for _key in "${_current_kernels[@]}"; do
   fi
 
   if [ -n "$new_kernel_shasum" ]; then
+    echo "Updating kernel shasum in PKGBUILD"
     sed -i "s|$old_kernel_shasum|$new_kernel_shasum|g" PKGBUILD
   fi
 
   if [ -n "$new_kernel_patch_shasum" ]; then
+    echo "Updating kernel patch shasum in PKGBUILD"
     sed -i "s|$old_kernel_patch_shasum|$new_kernel_patch_shasum|g" PKGBUILD
   fi
 


### PR DESCRIPTION
Hello!

I finally finished this work. So here's how this works:
- There's a script at the root of the repo, called `update-kernel-versions.sh`, that anyone can use on his own local copy of `linux-tkg` to bump versions automatically
  - It uses `git ls-remote` to fetch latest tags, and sources the `prepare` script to compare whats on the repo and what's upstream
  - If upstream offers a newer version, it changes
    - The `prepare` script with the newer numbers
    - Updates `PKGBUILD` sha sums by downloading both the older and newer archives to know which sha sum to replace with the newer one
      - rc-to-release changes are also taken care of, you need to always put the patch shasum on an rc kernel to `#upcoming_kernel_patch_sha256` (I was out of ideas for a better naming) so it can be found and replaced with the correct shasum
      - 5.xx (initial release) to 5.xx.y versions changes are also taken care of
  - It writes a file called `kernel_updates` where the kernel version bumps are written
- The  `update-kernel-versions.sh` script is then run by a workflow, every six hours (can also be triggered by hand). that will use the `kernel_updates` to push a commit with the correct information, where I am the author (so I take the glory for ALL kernel version bumps :smiling_imp: ) and FROGMINER, if that's okay (making only  FROGMINER as an author makes the commit message preview ugly on Github because the name appears twice).

I tested it and it works ! :dagger: 

Adel