### PR TITLE
Fix cpu-opt patch in "install.sh" and make "prepare" verbose about it

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -210,36 +210,16 @@ if [ "$1" = "install" ] || [ "$1" = "config" ]; then
 
   cd "$_where"
 
-  case "$_basever" in
-    "57")
+  if [ "$_basever" = "54" ]; then
+    opt_ver="4.19-5.4"
+  elif [ "$_basever" = "57" ]; then
     opt_ver="5.7"
     opt_alternative_url="true"
-    ;;
-    "58")
+  elif [[ "$_basever" =~ ^(58|59|510|511|512|513|514)$ ]]; then
     opt_ver="5.8-5.14"
-    ;;
-    "59")
-    opt_ver="5.8-5.14"
-    ;;
-    "510")
-    opt_ver="5.8-5.14"
-    ;;
-    "511")
-    opt_ver="5.8-5.14"
-    ;;
-    "512")
-    opt_ver="5.8-5.14"
-    ;;
-    "513")
-    opt_ver="5.8-5.14"
-    ;;
-    "514")
-    opt_ver="5.8-5.14"
-    ;;
-    "515")
+  else
     opt_ver="5.15+"
-    ;;
-  esac
+  fi
 
   if [ -n "$opt_ver" ]; then
     msg2 "Downloading Graysky2's CPU optimisations patch"

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -385,9 +385,7 @@ _tkg_patcher() {
     patch -Np1 -i "$tkgpatch" >> "$_where"/prepare.log || error "An error was encountered applying patches. It was logged to the prepare.log file."
     echo -e "\n" >> "$_where"/prepare.log
   else
-    if [[ $_msg != *graysky* ]]; then
-      msg2 "Skipping patch ${tkgpatch##*/}...\n         (unavailable for this kernel version)"
-    fi
+    msg2 "Skipping patch ${tkgpatch##*/}...\n         (unavailable for this kernel version)"
   fi
 }
 
@@ -438,23 +436,29 @@ _tkg_srcprep() {
   if [ -z $_debug ]; then
 
   # graysky's cpu opts - https://github.com/graysky2/kernel_compiler_patch
-  if [ "${_distro}" = "Arch" ]; then
-    tkgpatch="$srcdir/more-uarches-for-kernel-${opt_ver}.patch"
-  elif [ "${_distro}" = "Void" ]; then
-    tkgpatch="${wrksrc}/more-uarches-for-kernel-${opt_ver}.patch"
-  else
-    tkgpatch="$srcdir/more-uarches-for-kernel-${opt_ver}.patch"
-  fi
-  _msg="Applying graysky's cpu opts patch" && _tkg_patcher
+  if [ "$_basever" != "57" ]; then
+    # Newer version of the patches
+    if [ "${_distro}" = "Arch" ]; then
+      tkgpatch="$srcdir/more-uarches-for-kernel-${opt_ver}.patch"
+    elif [ "${_distro}" = "Void" ]; then
+      tkgpatch="${wrksrc}/more-uarches-for-kernel-${opt_ver}.patch"
+    else
+      tkgpatch="$srcdir/more-uarches-for-kernel-${opt_ver}.patch"
+    fi
+    _msg="Applying graysky's cpu opts patch" && _tkg_patcher
 
-  if [ "${_distro}" = "Arch" ]; then
-    tkgpatch="$srcdir/enable_additional_cpu_optimizations_for_gcc_v10.1%2B_kernel_v${opt_ver}.patch"
-  elif [ "${_distro}" = "Void" ]; then
-    tkgpatch="${wrksrc}/enable_additional_cpu_optimizations_for_gcc_v10.1+_kernel_v${opt_ver}.patch"
   else
-    tkgpatch="$srcdir/enable_additional_cpu_optimizations_for_gcc_v10.1+_kernel_v${opt_ver}+.patch"
+    # Edge case for 5.7
+    if [ "${_distro}" = "Arch" ]; then
+      tkgpatch="$srcdir/enable_additional_cpu_optimizations_for_gcc_v10.1%2B_kernel_v${opt_ver}.patch"
+    elif [ "${_distro}" = "Void" ]; then
+      tkgpatch="${wrksrc}/enable_additional_cpu_optimizations_for_gcc_v10.1+_kernel_v${opt_ver}.patch"
+    else
+      tkgpatch="$srcdir/enable_additional_cpu_optimizations_for_gcc_v10.1+_kernel_v${opt_ver}+.patch"
+    fi
+    _msg="Applying graysky's cpu opts patch (legacy)" && _tkg_patcher
+
   fi
-  _msg="Applying graysky's cpu opts patch (legacy)" && _tkg_patcher
 
   # PREEMPT_RT patch
   if [ "${_preempt_rt}" = "1" ]; then


### PR DESCRIPTION
This is the fix #438, with a small update to `install.sh` to have fewer lines of code and I also made `prepare` verbose about graysky's patches so we notice earlier if something is off.

Adel.
