### PR TITLE
uninstall-help for Debian

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -516,7 +516,7 @@ if [ "$1" = "uninstall-help" ]; then
 
   cd "$_where"
 
-  if [ "$_distro" = "Ubuntu" ]; then
+  if [[ "$_distro" =~ ^(Ubuntu|Debian)$ ]]; then
     msg2 "List of installed custom tkg kernels: "
     dpkg -l "*tkg*" | grep "linux.*tkg"
     dpkg -l "*linux-libc-dev*" | grep "linux.*tkg"


### PR DESCRIPTION
use the Ubuntu uninstall-help also when "_distro" is set to Debian like in the installation part