### PR TITLE
Fixes for the recent cpu uarch changes

### DIFF
--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -385,7 +385,7 @@ _tkg_patcher() {
     patch -Np1 -i "$tkgpatch" >> "$_where"/prepare.log || error "An error was encountered applying patches. It was logged to the prepare.log file."
     echo -e "\n" >> "$_where"/prepare.log
   else
-    msg2 "Skipping patch ${tkgpatch##*/}...\n         (unavailable for this kernel version)" #"
+    msg2 "Skipping patch %s...\n         (unavailable for this kernel version)" "${tkgpatch##*/}" #"
   fi
 }
 

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -454,7 +454,7 @@ _tkg_srcprep() {
     _patch_name="more-uarches-for-kernel-5.17%2B"
   fi
 
-  wget -P "${_patch_location}" "https://raw.githubusercontent.com/graysky2/kernel_compiler_patch/master/${_patch_name}.patch"
+  wget -O "${_patch_location}/${_patch_name}.patch" "https://raw.githubusercontent.com/graysky2/kernel_compiler_patch/master/${_patch_name}.patch"
   tkgpatch="${_patch_location}/${_patch_name}.patch"
   _msg="Applying graysky's cpu opts patch" && _tkg_patcher
 


### PR DESCRIPTION
Fixes the following error:

    /usr/share/makepkg/util/message.sh: line 69: printf: `B': invalid format character

and the patch not being applied because of a wrong file name.