### PR TITLE
Disable CACULE RDB support when _cacule_rdb equals to 'false'

### DIFF
--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -808,6 +808,9 @@ _tkg_srcprep() {
       _enable "CACULE_RDB"
       scripts/config --set-val "RDB_INTERVAL" "$_cacule_rdb_interval"
     fi
+    if [ "$_cacule_rdb" = "false" ]; then
+      _disable "CACULE_RDB"
+    fi
   elif [ "${_cpusched}" = "upds" ]; then
     # PDS default config
     _enable "SCHED_PDS"


### PR DESCRIPTION
Fixes #484 