### PR TITLE
Bug reports: create "logs" folder and populate it at each run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ src/*
 */pkg/
 pkg/*
 */linux-5*/
+*.myfrag
+logs/*

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+# If current run is not using 'script' for logging, do it
+if [ -z "$SCRIPT" ]; then
+  export SCRIPT=1
+  /usr/bin/script -q -e -c "$0 $@" shell-output.log
+  exit_status="$?"
+  sed -i 's/\x1b\[[0-9;]*m//g' shell-output.log
+  sed -i 's/\x1b(B//g' shell-output.log
+  mv -f shell-output.log logs/shell-output.log.txt
+  exit $exit_status
+fi
+
 # Stop the script at any ecountered error
 set -e
 

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -300,6 +300,9 @@ _tkg_initscript() {
     _path="${_where}"
   fi
 
+  # Create logs folder if doesn't exist already
+  mkdir -p "${_where}/logs"
+
   # Select Kernel version
   _set_kernel_version
 
@@ -331,7 +334,7 @@ user_patcher() {
       break
     done
 
-    echo -e "linux-tkg user patches, if any:\n" >> "$_where"/prepare.log
+    echo -e "linux-tkg user patches, if any:\n" >> "$_where"/logs/prepare.log.txt
 
 	# To patch the user because all your base are belong to us
 	local _patches=("$_where"/linux"$_basever"-tkg-userpatches/*."${_userpatch_ext}revert")
@@ -350,7 +353,7 @@ user_patcher() {
 	        msg2 ""
 	        msg2 "######################################################"
 	        patch -Np1 -R < "${_f}"
-	        echo "Reverted your own patch ${_f}" >> "$_where"/prepare.log
+	        echo "Reverted your own patch ${_f}" >> "$_where"/logs/prepare.log.txt
 	      fi
 	    done
 	  fi
@@ -372,7 +375,7 @@ user_patcher() {
 	        msg2 ""
 	        msg2 "######################################################"
 	        patch -Np1 < "${_f}"
-	        echo "Applied your own patch ${_f}" >> "$_where"/prepare.log
+	        echo "Applied your own patch ${_f}" >> "$_where"/logs/prepare.log.txt
 	      fi
 	    done
 	  fi
@@ -382,9 +385,9 @@ user_patcher() {
 _tkg_patcher() {
   if [ -e "$tkgpatch" ]; then
     msg2 "$_msg"
-    echo -e "### Applying ${tkgpatch##*/}... ###" >> "$_where"/prepare.log
-    patch -Np1 -i "$tkgpatch" >> "$_where"/prepare.log || error "An error was encountered applying patches. It was logged to the prepare.log file."
-    echo -e "\n" >> "$_where"/prepare.log
+    echo -e "### Applying ${tkgpatch##*/}... ###" >> "$_where"/logs/prepare.log.txt
+    patch -Np1 -i "$tkgpatch" >> "$_where"/logs/prepare.log.txt || error "An error was encountered applying patches. It was logged to the prepare.log.txt file."
+    echo -e "\n" >> "$_where"/logs/prepare.log.txt
   else
     msg2 "Skipping patch %s...\n         (unavailable for this kernel version)" "${tkgpatch##*/}" #"
   fi
@@ -397,7 +400,7 @@ _tkg_srcprep() {
 
   if [ "${_distro}" = "Arch" ]; then
     echo "-$pkgrel-tkg-${_cpusched}${_compiler_name}" > localversion.10-pkgrel
-    echo -e "Version tail set to \"-$pkgrel-tkg-${_cpusched}${_compiler_name}\"\n" > "$_where"/prepare.log
+    echo -e "Version tail set to \"-$pkgrel-tkg-${_cpusched}${_compiler_name}\"\n" > "$_where"/logs/prepare.log.txt
     echo "" > localversion.20-pkgname
     # add upstream patch
     if [ "$_sub" != "0" ] && [[ "$_sub" != rc* ]]; then
@@ -1426,7 +1429,7 @@ CONFIG_DEBUG_INFO_BTF_MODULES=y\r
 
   # rewrite configuration
   msg2 "Setting config"
-  make ${_config_updating} ${llvm_opt} |& tee -a "$_where"/prepare.log
+  make ${_config_updating} ${llvm_opt} |& tee -a "$_where"/logs/prepare.log.txt
 
   # menuconfig / nconfig
   if [ -z "$_menunconfig" ] && [ "$_distro" != "Void" ]; then
@@ -1577,6 +1580,25 @@ exit_cleanup() {
   msg2 'exit cleanup done\n'
   if [ -n "$_runtime" ]; then
     msg2 "compilation time : \n$_runtime"
+  fi
+
+  # Copy over the customization.cfg file to the logs folder
+  cp -f "$_where"/customization.cfg "$_where"/logs/customization.cfg.txt
+
+  # Create logs/system-info.txt
+  cat /etc/os-release > "$_where"/logs/system-info.txt
+  if command -v clang &> /dev/null; then
+    echo "#################" >> "$_where"/logs/system-info.txt
+    clang -v >> "$_where"/logs/system-info.txt 2>&1
+  fi
+  echo "#################" >> "$_where"/logs/system-info.txt
+  gcc -v >> "$_where"/logs/system-info.txt 2>&1
+
+  # Arch: move shell-output.log to logs folder
+  if [[ "$_distro" = "Arch" && -f "$_where"/shell-output.log ]]; then
+    mv -f "$_where"/shell-output.log "$_where"/logs/shell-output.log.txt
+    sed -i 's/\x1b\[[0-9;]*m//g' "$_where"/logs/shell-output.log.txt
+    sed -i 's/\x1b(B//g' "$_where"/logs/shell-output.log.txt
   fi
 }
 # Void has its own clean function, this breaks it so ignore it

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -300,7 +300,8 @@ _tkg_initscript() {
     _path="${_where}"
   fi
 
-  # Create logs folder if doesn't exist already
+  # Clean the logs folder
+  [ -e "${_where}/logs" ] && rm -rf "${_where}/logs"
   mkdir -p "${_where}/logs"
 
   # Select Kernel version

--- a/update-kernel-versions.sh
+++ b/update-kernel-versions.sh
@@ -13,6 +13,7 @@ kernel_tags=$(git -c 'versionsort.suffix=-' \
     | cut --delimiter='/' --fields=3)
 
 source linux-tkg-config/prepare
+trap - EXIT
 
 updates=""
 for _key in "${_current_kernels[@]}"; do


### PR DESCRIPTION
This makes it easier for people to open issues as we will ask them to attach every file in the "logs" folder that contains the logs for only the last build : 
-  a copy of `customization.cfg` that were used for the last build
- `prepare.log` 
-  the full output in the shell
   - in `install.sh`, this is achieved with the `script` command.
   - I couldn't firgure a seamless way for Arch people: to obtain the shell-output.log, we will ask them to do it by hand: `makepkg [args] | tee shell-output.log`
- system information (distro, version of `clang` and `gcc`), am I missing something here ?
these files have the `.txt` extension so they can easily be drag & dropped into Github issues.

Please make an issue template (I do not have permissions to do that) that:
- Asks people to describe their issue and ALWAYS attach the contents of their `logs` folder by drag & dropping each file into their issue message. And a special note for Arch users to always run `makepkg [args] | tee shell-output.log` (or to do it only when they get issues).
- Asks people to check for relevant keywords in the issues search bar, including closed issues, and maybe the solution is there already.

A little welcome QoL improvement :dagger: 
