### PR TITLE
update-kernel-versions.sh: Utilize sha256sums.asc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ pkg/*
 */linux-5*/
 *.myfrag
 logs/*
+kernel_updates
+gnupg/
+*sha256sum*


### PR DESCRIPTION
Partially replace downloading original files to checking with kernel.org checksum autosigner and sha256sums.asc


addition to https://github.com/Frogging-Family/linux-tkg/pull/432
adds a GnuPG dependency, but as far as I understand the current Github workflow should support this:
https://github.com/actions/virtual-environments/blob/ubuntu20/20220508.1/images/linux/Ubuntu2004-Readme.md