### PR TITLE
Predictable alphabetically sorted user fragment application

### DIFF
--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -1388,7 +1388,7 @@ CONFIG_DEBUG_INFO_BTF_MODULES=y\r
 
   if [ true = "$_config_fragments" ]; then
     local fragments=()
-    mapfile -d '' -t fragments < <(find "$_where"/ -type f -name "*.myfrag" -print0)
+    mapfile -d '' -t fragments < <(find "$_where"/ -type f -name "*.myfrag" -print0 | sort -z)
 
     if [ true = "$_config_fragments_no_confirm" ]; then
       printf 'Using config fragment %s\n' "${fragments[@]#$_where/}" #"


### PR DESCRIPTION
With more than one user kernel config fragment (*.myfrag files) the application of fragments is seemingly random based on find command output making incremental deliberate config fragment application impossible.

This PR adds ascending alphabetical sort operation on top of the find result (array of found files) when searching for user fragments so that fragments are later applied to default kernbel config in alphabetical order.