### PR TITLE
Fix hash for 5.18

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -767,7 +767,7 @@ case $_basever in
         0001-mm-Support-soft-dirty-flag-reset-for-VA-range.patch
         0002-mm-Support-soft-dirty-flag-read-with-reset.patch
     )
-    sha256sums=('da477700e2a5e91ae5b0a6f5c70b2618aab07aa39dcfe78106b9d742df411a24'
+    sha256sums=('51f3f1684a896e797182a0907299cc1f0ff5e5b51dd9a55478ae63a409855cee'
             #upcoming_kernel_patch_sha256
             '5dc559ed91c7d6e6c2893cad0819dfcf09e9792115bc69658891a5e9e902971f'
             '1e15fc2ef3fa770217ecc63a220e5df2ddbcf3295eb4a021171e7edd4c6cc898'


### PR DESCRIPTION
The hash for linux-5.18.tar.xz is incorrect, added the correct hash.