### PR TITLE
cfg: Add 5.18 to kernel list

### DIFF
--- a/customization.cfg
+++ b/customization.cfg
@@ -5,7 +5,7 @@
 # If left empty, the script will prompt
 _distro=""
 
-# Kernel Version - Options are "5.4", "5.7", "5.8", "5.9", "5.10", "5.11", "5.12", "5.13", "5.14", "5.15", "5.16", "5.17"
+# Kernel Version - Options are "5.4", "5.7", "5.8", "5.9", "5.10", "5.11", "5.12", "5.13", "5.14", "5.15", "5.16", "5.17", "5.18"
 _version=""
 
 #### MISC OPTIONS ####


### PR DESCRIPTION
It has just been bumped from rc7 to the release (79e921e86acfc28e6c1ca73d555ef289b788f166)