### PR TITLE
Replace instances of `--output-dir` from curl commands

### DIFF
--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -615,20 +615,20 @@ _tkg_srcprep() {
     _msg="Applying TT patch"
     if [ "${_distro}" = "Void" ]; then
       if [[ $_basever = 515 ]]; then
-        curl --output-dir "$wrksrc" -o "tt.patch" "https://raw.githubusercontent.com/ptr1337/kernel-patches/master/${_basekernel}/TT/0001-tt-r3.patch"
+        curl "https://raw.githubusercontent.com/ptr1337/kernel-patches/master/${_basekernel}/TT/0001-tt-r3.patch" > "$wrksrc"/tt.patch 
       elif [[ $_basever = 517 ]]; then
-        curl --output-dir "$wrksrc" -o "tt.patch" "https://raw.githubusercontent.com/ptr1337/kernel-patches/master/${_basekernel}/sched/0001-tt.patch"
+        curl "https://raw.githubusercontent.com/ptr1337/kernel-patches/master/${_basekernel}/sched/0001-tt.patch" > "$wrksrc"/tt.patch
       else
-        curl --output-dir "$wrksrc" -o "tt.patch" "https://raw.githubusercontent.com/ptr1337/kernel-patches/master/${_basekernel}/sched/0001-tt-${_basekernel}.patch"
+        curl "https://raw.githubusercontent.com/ptr1337/kernel-patches/master/${_basekernel}/sched/0001-tt-${_basekernel}.patch" > "$wrksrc"/tt.patch
       fi
       tkgpatch="$wrksrc/tt.patch" && _tkg_patcher
     else
       if [[ $_basever = 515 ]]; then
-         curl --output-dir "$srcdir" -o "tt.patch" "https://raw.githubusercontent.com/ptr1337/kernel-patches/master/${_basekernel}/TT/0001-tt-r3.patch"
+         curl "https://raw.githubusercontent.com/ptr1337/kernel-patches/master/${_basekernel}/TT/0001-tt-r3.patch" > "$srcdir"/tt.patch
       elif [[ $_basever = 517 ]]; then
-         curl --output-dir "$srcdir" -o "tt.patch" "https://raw.githubusercontent.com/ptr1337/kernel-patches/master/${_basekernel}/sched/0001-tt.patch"
+         curl "https://raw.githubusercontent.com/ptr1337/kernel-patches/master/${_basekernel}/sched/0001-tt.patch" > "$srcdir"/tt.patch
       else
-         curl --output-dir "$srcdir" -o "tt.patch" "https://raw.githubusercontent.com/ptr1337/kernel-patches/master/${_basekernel}/sched/0001-tt-${_basekernel}.patch"
+         curl "https://raw.githubusercontent.com/ptr1337/kernel-patches/master/${_basekernel}/sched/0001-tt-${_basekernel}.patch" > "$srcdir"/tt.patch
       fi
       tkgpatch="$srcdir/tt.patch" && _tkg_patcher
     fi


### PR DESCRIPTION
Given that the `--output-dir` was only argument was added in cURL version 7.73.0 (released October 14th, 2020), Ubuntu 20.04 and distributions based on it (among others, I'm sure) do not yet have this argument in the version of cURL that they ship.

This pull replaces the `--output-dir` argument with shell redirection to enable use on the aforementioned distros.