### PR TITLE
Revert "Disable cacule availability on 5.18. The patchset results in …

### DIFF
--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -199,7 +199,7 @@ _set_cpu_scheduler() {
   elif [ "$_basever" = "517" ]; then
     _avail_cpu_scheds=("pds" "bmq" "cacule" "tt" "cfs")
   elif [ "$_basever" = "518" ]; then
-    _avail_cpu_scheds=("pds" "bmq" "tt" "cfs")
+    _avail_cpu_scheds=("pds" "bmq" "cacule" "tt" "cfs")
   else
     _avail_cpu_scheds=("cfs")
   fi


### PR DESCRIPTION
…non-booting kernels currently."

This reverts commit 2b225b594ad1bd2b644a2e9c107a4be232942ab7.

fixed cacULE-5.18 patchset with commit https://github.com/ptr1337/kernel-patches/commit/2adb46deccaf3c80dd8e94c87e9904981e20c459

Signed-off-by: Peter Jung <admin@ptr1337.dev>