### PR TITLE
Enable TT for 5.19rc and TT High HZ patch for 5.15

### DIFF
--- a/customization.cfg
+++ b/customization.cfg
@@ -201,7 +201,7 @@ _cacule_rdb="false"
 _cacule_rdb_interval="19"
 
 # TT only - Enable High HZ patch (available for 5.15 only) - Default is "false"
-_tt_high_hz="true"
+_tt_high_hz="false"
 
 # MuQSS and PDS only - SMT (Hyperthreading) aware nice priority and policy support (SMT_NICE) - Kernel default is "true" - You can disable this on non-SMT/HT CPUs for lower overhead
 _smt_nice=""

--- a/customization.cfg
+++ b/customization.cfg
@@ -200,6 +200,9 @@ _cacule_rdb="false"
 # https://github.com/hamadmarri/cacule-cpu-scheduler/blob/master/patches/CacULE/RDB/rdb.patch#L56
 _cacule_rdb_interval="19"
 
+# TT only - Enable High HZ patch (available for 5.15 only) - Default is "false"
+_tt_high_hz="true"
+
 # MuQSS and PDS only - SMT (Hyperthreading) aware nice priority and policy support (SMT_NICE) - Kernel default is "true" - You can disable this on non-SMT/HT CPUs for lower overhead
 _smt_nice=""
 

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -201,6 +201,8 @@ _set_cpu_scheduler() {
     _avail_cpu_scheds=("pds" "bmq" "cacule" "tt" "cfs")
   elif [ "$_basever" = "518" ]; then
     _avail_cpu_scheds=("pds" "bmq" "cacule" "tt" "cfs")
+  elif [ "$_basever" = "519" ]; then
+    _avail_cpu_scheds=("tt" "cfs")
   else
     _avail_cpu_scheds=("cfs")
   fi
@@ -633,6 +635,16 @@ _tkg_srcprep() {
       fi
       tkgpatch="$srcdir/tt.patch" && _tkg_patcher
     fi
+    if [ "$_tt_high_hz" = "true" ] && [ $_basever = 515 ]; then
+      _msg="Applying TT High HZ patch"
+      if [ "${_distro}" = "Void" ]; then
+        curl "https://raw.githubusercontent.com/hamadmarri/TT-CPU-Scheduler/master/patches/${_basekernel}/high-hz.patch" > "$wrksrc"/tt_high_hz.patch
+        tkgpatch="$wrksrc/tt_high_hz.patch" && _tkg_patcher
+      else
+        curl "https://raw.githubusercontent.com/hamadmarri/TT-CPU-Scheduler/master/patches/${_basekernel}/high-hz.patch" > "$srcdir"/tt_high_hz.patch
+        tkgpatch="$srcdir/tt_high_hz.patch" && _tkg_patcher
+      fi
+    fi 
   elif [ "${_cpusched}" = "cfs" ]; then
     _msg="Applying Glitched CFS patch"
     tkgpatch="$srcdir/0003-glitched-cfs.patch" && _tkg_patcher


### PR DESCRIPTION
Allows users to select the TaskType scheduler for the 5.19rc (tested to build and boot successfully).

Also allows enabling the High HZ patch for 5.15 in the config (solves #532). I do not personally use this patch, but I figure there is no harm in giving the option to those who want it (again, able to build and boot this configuration successfully).

If changes should be required for the implementation of the TT High HZ patch, I am happy to make them upon request.