### PR TITLE
Support `doas` and `su` for root authentication

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,14 @@ set -e
 _where=`pwd`
 srcdir="$_where"
 
+# Command used for superuser privileges (`sudo`, `doas`, `su`)
+if [ ! -x "$(command -v sudo)" ]; then
+	if [ -x "$(command -v doas)" ]; then sudo() { doas "$@"; }
+	elif [ -x "$(command -v su)" -a -x "$(command -v xargs)" ]; then
+		sudo() { echo "$@" | xargs -I {} su -c '{}'; }
+	fi
+fi
+
 source customization.cfg
 
 source linux-tkg-config/prepare


### PR DESCRIPTION
I ran the script and many moments later, I was disappointed because I got the error `sudo: command not found`. This is because I use `doas` instead. Some people use `doas` or `su` instead of `sudo` so they do not have it installed. This change should automatically detect if the user has sudo installed, and if it is not, check if doas is installed, then check if su is installed.