### PR TITLE
linux60: Fix Winesync patchset for 6.0-rc6

### DIFF
--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -1573,8 +1573,8 @@ CONFIG_DEBUG_INFO_BTF_MODULES=y\r
       _msg="Patching winesync/fastsync support"
       _tkg_patcher
       _module "WINESYNC"
-      echo "KERNEL==\"winesync\", MODE=\"0644\"" > ../winesync.rules
-      echo "winesync" > ../winesync.conf
+      echo "KERNEL==\"winesync\", MODE=\"0644\"" > "${srcdir}"/winesync.rules
+      echo "winesync" > "${srcdir}"/winesync.conf
     fi
   fi
 

--- a/linux-tkg-patches/6.0/0007-v6.0-winesync.patch
+++ b/linux-tkg-patches/6.0/0007-v6.0-winesync.patch
@@ -12,12 +12,12 @@ Subject: [PATCH 01/34] winesync: Introduce the winesync driver and character
  create mode 100644 drivers/misc/winesync.c
 
 diff --git a/drivers/misc/Kconfig b/drivers/misc/Kconfig
-index 0f5a49fc7c9e..e21e4424d6a2 100644
+index 94e9fb4cdd76..4f9e3d80a6e8 100644
 --- a/drivers/misc/Kconfig
 +++ b/drivers/misc/Kconfig
-@@ -470,6 +470,17 @@ config OPEN_DICE
+@@ -496,6 +496,17 @@ config VCPU_STALL_DETECTOR
  
- 	  If unsure, say N.
+ 	  If you do not intend to run this kernel as a guest, say N.
  
 +config WINESYNC
 +	tristate "Synchronization primitives for Wine"
@@ -34,16 +34,18 @@ index 0f5a49fc7c9e..e21e4424d6a2 100644
  source "drivers/misc/eeprom/Kconfig"
  source "drivers/misc/cb710/Kconfig"
 diff --git a/drivers/misc/Makefile b/drivers/misc/Makefile
-index a086197af544..1fb39bc4637b 100644
+index 2be8542616dd..d061fe45407b 100644
 --- a/drivers/misc/Makefile
 +++ b/drivers/misc/Makefile
-@@ -58,5 +58,6 @@ obj-$(CONFIG_HABANA_AI)		+= habanalabs/
+@@ -58,6 +58,7 @@ obj-$(CONFIG_HABANA_AI)		+= habanalabs/
  obj-$(CONFIG_UACCE)		+= uacce/
  obj-$(CONFIG_XILINX_SDFEC)	+= xilinx_sdfec.o
  obj-$(CONFIG_HISI_HIKEY_USB)	+= hisi_hikey_usb.o
 +obj-$(CONFIG_WINESYNC)		+= winesync.o
  obj-$(CONFIG_HI6421V600_IRQ)	+= hi6421v600-irq.o
  obj-$(CONFIG_OPEN_DICE)		+= open-dice.o
+ obj-$(CONFIG_VCPU_STALL_DETECTOR)	+= vcpu_stall_detector.o
+\ No newline at end of file
 diff --git a/drivers/misc/winesync.c b/drivers/misc/winesync.c
 new file mode 100644
 index 000000000000..111f33c5676e
@@ -115,7 +117,7 @@ index 000000000000..111f33c5676e
 +MODULE_LICENSE("GPL");
 +MODULE_ALIAS("devname:" WINESYNC_NAME);
 -- 
-2.36.0
+2.37.3
 
 From 1f142d40cb7537bd936a68cadaf0f2a0d94abd62 Mon Sep 17 00:00:00 2001
 From: Zebediah Figura <zfigura@codeweavers.com>
@@ -146,10 +148,10 @@ index c07dc0ee860e..4e5abe508426 100644
  
    11 char	Raw keyboard device	(Linux/SPARC only)
 diff --git a/Documentation/userspace-api/ioctl/ioctl-number.rst b/Documentation/userspace-api/ioctl/ioctl-number.rst
-index cfe6cccf0f44..d31e014d7bcb 100644
+index 3b985b19f39d..3f313fd4338c 100644
 --- a/Documentation/userspace-api/ioctl/ioctl-number.rst
 +++ b/Documentation/userspace-api/ioctl/ioctl-number.rst
-@@ -371,6 +371,8 @@ Code  Seq#    Include File                                           Comments
+@@ -375,6 +375,8 @@ Code  Seq#    Include File                                           Comments
                                                                       <mailto:thomas@winischhofer.net>
  0xF6  all                                                            LTTng Linux Trace Toolkit Next Generation
                                                                       <mailto:mathieu.desnoyers@efficios.com>
@@ -2177,10 +2179,10 @@ diff --git a/tools/testing/selftests/Makefile b/tools/testing/selftests/Makefile
 index c852eb40c4f7..a366016d6254 100644
 --- a/tools/testing/selftests/Makefile
 +++ b/tools/testing/selftests/Makefile
-@@ -13,6 +13,7 @@ TARGETS += damon
- TARGETS += drivers/dma-buf
+@@ -14,6 +14,7 @@ TARGETS += drivers/dma-buf
  TARGETS += drivers/s390x/uvdevice
  TARGETS += drivers/net/bonding
+ TARGETS += drivers/net/team
 +TARGETS += drivers/winesync
  TARGETS += efivarfs
  TARGETS += exec
@@ -3282,10 +3284,10 @@ Subject: [PATCH 20/34] maintainers: Add an entry for winesync.
  1 file changed, 9 insertions(+)
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index af9530d98717..f51064fca6e9 100644
+index 72b9654f764c..ff31beb17835 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
-@@ -20536,6 +20536,15 @@ M:	David Härdeman <david@hardeman.nu>
+@@ -21920,6 +21920,15 @@ M:	David Härdeman <david@hardeman.nu>
  S:	Maintained
  F:	drivers/media/rc/winbond-cir.c
  
@@ -3299,10 +3301,10 @@ index af9530d98717..f51064fca6e9 100644
 +F:	tools/testing/selftests/drivers/winesync/
 +
  WINSYSTEMS EBC-C384 WATCHDOG DRIVER
- M:	William Breathitt Gray <vilhelm.gray@gmail.com>
+ M:	William Breathitt Gray <william.gray@linaro.org>
  L:	linux-watchdog@vger.kernel.org
 -- 
-2.36.0
+2.37.3
 
 From 4e6e34339182f13972e7b906c0bd0dde74eda3d7 Mon Sep 17 00:00:00 2001
 From: Zebediah Figura <zfigura@codeweavers.com>
@@ -4493,10 +4495,10 @@ Subject: [PATCH 31/34] winesync: Introduce alertable waits.
  2 files changed, 60 insertions(+), 10 deletions(-)
 
 diff --git a/drivers/misc/winesync.c b/drivers/misc/winesync.c
-index 0f8a8a94eef8..64b379d846db 100644
+index 4fbf231a7909..7a28f58dbbf2 100644
 --- a/drivers/misc/winesync.c
 +++ b/drivers/misc/winesync.c
-@@ -842,10 +842,11 @@ static int setup_wait(struct winesync_device *dev,
+@@ -841,10 +841,11 @@ static int setup_wait(struct winesync_device *dev,
  	const __u32 count = args->count;
  	struct winesync_q *q;
  	ktime_t timeout = 0;
@@ -4509,7 +4511,7 @@ index 0f8a8a94eef8..64b379d846db 100644
  		return -EINVAL;
  
  	if (args->timeout) {
-@@ -859,7 +860,11 @@ static int setup_wait(struct winesync_device *dev,
+@@ -858,7 +859,11 @@ static int setup_wait(struct winesync_device *dev,
  		timeout = timespec64_to_ns(&to);
  	}
  
@@ -4522,7 +4524,7 @@ index 0f8a8a94eef8..64b379d846db 100644
  	if (!ids)
  		return -ENOMEM;
  	if (copy_from_user(ids, u64_to_user_ptr(args->objs),
-@@ -867,8 +872,10 @@ static int setup_wait(struct winesync_device *dev,
+@@ -866,8 +871,10 @@ static int setup_wait(struct winesync_device *dev,
  		kfree(ids);
  		return -EFAULT;
  	}
@@ -4534,7 +4536,7 @@ index 0f8a8a94eef8..64b379d846db 100644
  	if (!q) {
  		kfree(ids);
  		return -ENOMEM;
-@@ -880,7 +887,7 @@ static int setup_wait(struct winesync_device *dev,
+@@ -879,7 +886,7 @@ static int setup_wait(struct winesync_device *dev,
  	q->ownerdead = false;
  	q->count = count;
  
@@ -4543,7 +4545,7 @@ index 0f8a8a94eef8..64b379d846db 100644
  		struct winesync_q_entry *entry = &q->entries[i];
  		struct winesync_obj *obj = get_obj(dev, ids[i]);
  
-@@ -935,9 +942,9 @@ static int winesync_wait_any(struct winesync_device *dev, void __user *argp)
+@@ -934,9 +941,9 @@ static int winesync_wait_any(struct winesync_device *dev, void __user *argp)
  {
  	struct winesync_wait_args args;
  	struct winesync_q *q;
@@ -4554,7 +4556,7 @@ index 0f8a8a94eef8..64b379d846db 100644
  	int ret;
  
  	if (copy_from_user(&args, argp, sizeof(args)))
-@@ -947,9 +954,13 @@ static int winesync_wait_any(struct winesync_device *dev, void __user *argp)
+@@ -946,9 +953,13 @@ static int winesync_wait_any(struct winesync_device *dev, void __user *argp)
  	if (ret < 0)
  		return ret;
  
@@ -4569,7 +4571,7 @@ index 0f8a8a94eef8..64b379d846db 100644
  		struct winesync_q_entry *entry = &q->entries[i];
  		struct winesync_obj *obj = entry->obj;
  
-@@ -958,9 +969,15 @@ static int winesync_wait_any(struct winesync_device *dev, void __user *argp)
+@@ -957,9 +968,15 @@ static int winesync_wait_any(struct winesync_device *dev, void __user *argp)
  		spin_unlock(&obj->lock);
  	}
  
@@ -4587,7 +4589,7 @@ index 0f8a8a94eef8..64b379d846db 100644
  		struct winesync_obj *obj = q->entries[i].obj;
  
  		if (atomic_read(&q->signaled) != -1)
-@@ -977,7 +994,7 @@ static int winesync_wait_any(struct winesync_device *dev, void __user *argp)
+@@ -976,7 +993,7 @@ static int winesync_wait_any(struct winesync_device *dev, void __user *argp)
  
  	/* and finally, unqueue */
  
@@ -4596,7 +4598,7 @@ index 0f8a8a94eef8..64b379d846db 100644
  		struct winesync_q_entry *entry = &q->entries[i];
  		struct winesync_obj *obj = entry->obj;
  
-@@ -1037,6 +1054,14 @@ static int winesync_wait_all(struct winesync_device *dev, void __user *argp)
+@@ -1036,6 +1053,14 @@ static int winesync_wait_all(struct winesync_device *dev, void __user *argp)
  		 */
  		list_add_tail(&entry->node, &obj->all_waiters);
  	}
@@ -4611,7 +4613,7 @@ index 0f8a8a94eef8..64b379d846db 100644
  
  	/* check if we are already signaled */
  
-@@ -1044,6 +1069,21 @@ static int winesync_wait_all(struct winesync_device *dev, void __user *argp)
+@@ -1043,6 +1068,21 @@ static int winesync_wait_all(struct winesync_device *dev, void __user *argp)
  
  	spin_unlock(&dev->wait_all_lock);
  
@@ -4633,7 +4635,7 @@ index 0f8a8a94eef8..64b379d846db 100644
  	/* sleep */
  
  	ret = winesync_schedule(q, args.timeout ? &timeout : NULL);
-@@ -1066,6 +1106,16 @@ static int winesync_wait_all(struct winesync_device *dev, void __user *argp)
+@@ -1065,6 +1105,16 @@ static int winesync_wait_all(struct winesync_device *dev, void __user *argp)
  
  		put_obj(obj);
  	}
@@ -4664,7 +4666,7 @@ index fb3788339ffe..5b4e369f7469 100644
  
  #define WINESYNC_IOC_BASE 0xf7
 -- 
-2.36.0
+2.37.3
 
 From 127efad71a0702a68890097b114b3467c234259f Mon Sep 17 00:00:00 2001
 From: Zebediah Figura <zfigura@codeweavers.com>


### PR DESCRIPTION
small change for smooth applying
Fixes https://github.com/Frogging-Family/linux-tkg/issues/612

also respect https://github.com/Frogging-Family/linux-tkg/pull/591 and make winesync workarounds more stable
Resolves https://github.com/Frogging-Family/linux-tkg/issues/604