### PR TITLE
fix mkspec patches

### DIFF
--- a/linux-tkg-patches/5.10/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.10/0013-fedora-rpm.patch
@@ -17,6 +17,7 @@ index 7c477ca7d..1158f5559 100755
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
++	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
 @@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Obsoletes: kernel-headers

--- a/linux-tkg-patches/5.11/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.11/0013-fedora-rpm.patch
@@ -17,6 +17,7 @@ index 7c477ca7d..1158f5559 100755
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
++	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
 @@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Obsoletes: kernel-headers

--- a/linux-tkg-patches/5.12/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.12/0013-fedora-rpm.patch
@@ -17,6 +17,7 @@ index 7c477ca7d..1158f5559 100755
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
++	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
 @@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Obsoletes: kernel-headers

--- a/linux-tkg-patches/5.13/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.13/0013-fedora-rpm.patch
@@ -17,6 +17,7 @@ index 7c477ca7d..1158f5559 100755
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
++	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
 @@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Obsoletes: kernel-headers

--- a/linux-tkg-patches/5.14/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.14/0013-fedora-rpm.patch
@@ -17,6 +17,7 @@ index 7c477ca7d..1158f5559 100755
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
++	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
 @@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Obsoletes: kernel-headers

--- a/linux-tkg-patches/5.15/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.15/0013-fedora-rpm.patch
@@ -17,6 +17,7 @@ index 7c477ca7d..1158f5559 100755
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
++	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
 @@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Obsoletes: kernel-headers

--- a/linux-tkg-patches/5.16/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.16/0013-fedora-rpm.patch
@@ -17,6 +17,7 @@ index 7c477ca7d..1158f5559 100755
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
++	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
 @@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Obsoletes: kernel-headers

--- a/linux-tkg-patches/5.17/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.17/0013-fedora-rpm.patch
@@ -17,6 +17,7 @@ index 7c477ca7d..1158f5559 100755
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
++	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
 @@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Obsoletes: kernel-headers

--- a/linux-tkg-patches/5.18/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.18/0013-fedora-rpm.patch
@@ -16,6 +16,7 @@ index 7c477ca7d..1158f5559 100755
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
++	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
 @@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Obsoletes: kernel-headers

--- a/linux-tkg-patches/5.19/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.19/0013-fedora-rpm.patch
@@ -16,6 +16,7 @@ index 7c477ca7d..1158f5559 100755
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
++	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
 @@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Obsoletes: kernel-headers

--- a/linux-tkg-patches/5.4/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.4/0013-fedora-rpm.patch
@@ -17,6 +17,7 @@ index 7c477ca7d..1158f5559 100755
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
++	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
 @@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Obsoletes: kernel-headers

--- a/linux-tkg-patches/5.7/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.7/0013-fedora-rpm.patch
@@ -17,6 +17,7 @@ index 7c477ca7d..1158f5559 100755
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
++	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
 @@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Obsoletes: kernel-headers

--- a/linux-tkg-patches/5.8/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.8/0013-fedora-rpm.patch
@@ -17,6 +17,7 @@ index 7c477ca7d..1158f5559 100755
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
++	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
 @@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Obsoletes: kernel-headers

--- a/linux-tkg-patches/5.9/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.9/0013-fedora-rpm.patch
@@ -17,6 +17,7 @@ index 7c477ca7d..1158f5559 100755
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
++	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
 @@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Obsoletes: kernel-headers

--- a/linux-tkg-patches/6.0/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/6.0/0013-fedora-rpm.patch
@@ -16,6 +16,7 @@ index 7c477ca7d..1158f5559 100755
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
++	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
 @@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Obsoletes: kernel-headers


### PR DESCRIPTION
Current mkspec patches do not make `kernel` package provide `kernel-uname-r` package, which is e. g. necessary to build nvidia kmods manually.