### PR TITLE
Clarify the description of the tickless parameter

### DIFF
--- a/customization.cfg
+++ b/customization.cfg
@@ -144,7 +144,9 @@ _numadisable="false"
 _misc_adds="true"
 
 # Set to "0" for periodic ticks, "1" to use CattaRappa mode (enabling full tickless) and "2" for tickless idle only.
-# Full tickless can give higher performances in various cases but, depending on hardware, lower consistency. Just tickless idle can perform better on some platforms (mostly AMD based).
+# Full tickless can give higher performances in case you use isolation of CPUs for tasks
+# and it works only when using the nohz_full kernel parameter, otherwise behaves like idle.
+# Just tickless idle perform better for most platforms.
 _tickless=""
 
 # Set to "true" to use ACS override patch - https://wiki.archlinux.org/index.php/PCI_passthrough_via_OVMF#Bypassing_the_IOMMU_groups_.28ACS_override_patch.29 - Kernel default is "false"

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -1328,7 +1328,7 @@ _tkg_srcprep() {
     plain "Use CattaRappa mode (Tickless/Dynticks) ?"
     _tickless_array_text=(
       "No, use periodic ticks."
-      "Yes, full tickless baby!\n        Can give higher performances in many cases but lower consistency on some hardware."
+      "Yes, full tickless baby!\n       Full tickless can give higher performances in case you use isolation of CPUs for task, in other cases it behaves as Idle."
       "Just tickless idle plz.\n        Just tickless idle can perform better with some platforms (mostly AMD) or CPU schedulers (mostly MuQSS)."
     )
     _default_index="2"


### PR DESCRIPTION
The linux-tkg has a `_tickless` parameter which controls how the scheduling-clock interrupts behaves in the kernel. There is a Full dynticks mode is described as "Can provide better performance in many cases". The problem is that it is not specified here that without passed `nohz_full` kernel parameter it works the same way as Idle dynticks which is described in kernel option description. Even so, Full dynticks only makes sense when there is one single task running on the processor core (see https://docs.kernel.org/timers/no_hz.html?highlight=tickless#omit-scheduling-clock-ticks-for-cpus-with-only-one-runnable-task) and there are no other tasks to switch. I think this case may be relevant only when isolating CPUs, but not for desktop tasks or games, but I could be wrong.