### PR TITLE
Add Torvalds' git repo for faster -rc kernel evaluation

### DIFF
--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -11,6 +11,7 @@ _kernel_git_remotes=(
   ["kernel.org"]="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git"
   ["googlesource.com"]="https://kernel.googlesource.com/pub/scm/linux/kernel/git/stable/linux-stable"
   ["github.com"]="https://github.com/gregkh/linux.git"
+  ["torvalds"]="https://github.com/torvalds/linux.git"
 )
 
 _git_remote_names=( "${!_kernel_git_remotes[@]}" )
@@ -424,6 +425,7 @@ _linux_git_branch_checkout() {
       msg2 "master branch doesn't locally exist, shallow cloning..."
       git remote set-branches --add kernel.org master
       git remote set-branches --add googlesource.com master
+      git remote set-branches --add torvalds master
       git fetch --depth=1 $_git_mirror master
       git fetch --depth 1 $_git_mirror tag "$_kernel_git_tag"
       git checkout -b master-${_git_mirror} ${_git_mirror}/master
@@ -441,6 +443,7 @@ _linux_git_branch_checkout() {
       msg2 "${_basekernel}.y branch doesn't locally exist, shallow cloning..."
       git remote set-branches --add kernel.org linux-${_basekernel}.y
       git remote set-branches --add googlesource.com linux-${_basekernel}.y
+      git remote set-branches --add torvalds linux-${_basekernel}.y
       git fetch --depth=1 $_git_mirror linux-${_basekernel}.y
       git fetch --depth=1 $_git_mirror tag "$_kernel_git_tag"
       git checkout -b linux-${_basekernel}-${_git_mirror} ${_git_mirror}/linux-${_basekernel}.y


### PR DESCRIPTION
This adds additional git repo from Linus Torvalds to `linux-src-git` which allows to switch to and evaluate recent -rc kernels immediately after commited by Linus.