### PR TITLE
Enable MGLRU support in prjc

### DIFF
--- a/linux-tkg-patches/6.0/0009-prjc_v6.0-r0.patch
+++ b/linux-tkg-patches/6.0/0009-prjc_v6.0-r0.patch
@@ -635,7 +635,7 @@ new file mode 100644
 index 000000000000..03e3956194f7
 --- /dev/null
 +++ b/kernel/sched/alt_core.c
-@@ -0,0 +1,7887 @@
+@@ -0,0 +1,7890 @@
 +/*
 + *  kernel/sched/alt_core.c
 + *
@@ -4306,6 +4306,9 @@ index 000000000000..03e3956194f7
 +		 * finish_task_switch()'s mmdrop().
 +		 */
 +		switch_mm_irqs_off(prev->active_mm, next->mm, next);
++#ifdef CONFIG_LRU_GEN_ENABLED
++		lru_gen_use_mm(next->mm);
++#endif
 +
 +		if (!prev->mm) {                        // from kernel
 +			/* will mmdrop() in finish_task_switch(). */
@@ -9477,7 +9480,7 @@ index 667876da8382..a416d4bedd98 100644
   * to the console
 @@ -215,6 +216,7 @@ static const struct file_operations sched_scaling_fops = {
  };
- 
+
  #endif /* SMP */
 +#endif /* !CONFIG_SCHED_ALT */
 
@@ -9897,7 +9900,7 @@ index 205d605cacc5..7dd950601cca 100644
 @@ -86,6 +86,10 @@
 
  /* Constants used for minimum and  maximum */
- 
+
 +#ifdef CONFIG_SCHED_ALT
 +extern int sched_yield_type;
 +#endif


### PR DESCRIPTION
Hey Mr. Etienne, since [mglru is enabled by default](https://github.com/Frogging-Family/linux-tkg/blob/b8835ca20232e4bbf0738bd4e25bcffeb917ad57/customization.cfg#L162) it is worth adding support in BMQ/PDS