### PR TITLE
linux 5.15.y: Update compatibility fix for old Fsync ABI

### DIFF
--- a/linux-tkg-patches/5.15/0007-v5.15-fsync1_via_futex_waitv.patch
+++ b/linux-tkg-patches/5.15/0007-v5.15-fsync1_via_futex_waitv.patch
@@ -14,7 +14,7 @@ of Proton to still use fsync in new kernel releases.
 Signed-off-by: André Almeida <andrealmeid@collabora.com>
 ---
  include/uapi/linux/futex.h | 12 ++++++
- kernel/futex.c             | 75 +++++++++++++++++++++++++++++++++++++-
+ kernel/futex/core.c        | 75 +++++++++++++++++++++++++++++++++++++-
  2 files changed, 86 insertions(+), 1 deletion(-)
 
 diff --git a/include/uapi/linux/futex.h b/include/uapi/linux/futex.h
@@ -47,10 +47,10 @@ index 2a06b99f9803..417c5d89b745 100644
  
  /*
   * Support for robust futexes: the kernel cleans up held futexes at
-diff --git a/kernel/futex.c b/kernel/futex.c
+diff --git a/kernel/futex/core.c b/kernel/futex/core.c
 index 4a9e7ce3714a..c3f2e65afab8 100644
---- a/kernel/futex.c
-+++ b/kernel/futex.c
+--- a/kernel/futex/core.c
++++ b/kernel/futex/core.c
 @@ -4012,6 +4012,7 @@ static __always_inline bool futex_cmd_has_timeout(u32 cmd)
  	case FUTEX_LOCK_PI2:
  	case FUTEX_WAIT_BITSET:


### PR DESCRIPTION
addition to https://github.com/Frogging-Family/linux-tkg/pull/676

Fixes https://github.com/Frogging-Family/linux-tkg/issues/679