### PR TITLE
Various fixes for the RPM target

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -249,7 +249,7 @@ if [ "$1" = "install" ]; then
       _extra_ver_str="_${_kernel_flavor}"
     fi
 
-    _fedora_work_dir="$_kernel_work_folder/linux-tkg-rpmbuild"
+    _fedora_work_dir="$_kernel_work_folder_abs/linux-tkg-rpmbuild"
 
     msg2 "Building kernel RPM packages"
     RPMOPTS="--define '_topdir ${_fedora_work_dir}'" make ${llvm_opt} -j ${_thread_num} rpm-pkg EXTRAVERSION="${_extra_ver_str}"

--- a/install.sh
+++ b/install.sh
@@ -416,7 +416,7 @@ if [ "$1" = "uninstall-help" ]; then
     msg2 "Note: linux-libc-dev packages are no longer created and installed, you can safely remove any remnants."
   elif [ "$_distro" = "Fedora" ]; then
     msg2 "List of installed custom tkg kernels: "
-    dnf list --installed kernel*
+    dnf list --installed | grep -i "tkg"
     msg2 "To uninstall a version, you should remove the kernel, kernel-headers and kernel-devel associated to it (if installed), with: "
     msg2 "      sudo dnf remove --noautoremove kernel-VERSION kernel-devel-VERSION kernel-headers-VERSION"
     msg2 "       where VERSION is displayed in the second column"

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -692,10 +692,8 @@ _tkg_srcprep() {
     _msg="Applying glitched base non-rt additions patch" && _tkg_patcher
   fi
 
-  if [[ "$_distro" =~ ^(Fedora|Suse)$ ]]; then
-    tkgpatch="$srcdir/0013-fedora-rpm.patch"
-    _msg="RPM: fixing spec generator" && _tkg_patcher
-  fi
+  tkgpatch="$srcdir/0013-fedora-rpm.patch"
+  _msg="RPM: fixing spec generator" && _tkg_patcher
 
   if [ -z $_misc_adds ]; then
     plain "Enable misc additions ? They may contain temporary fixes pending upstream, or some other changes that can break on non-Arch distros."

--- a/linux-tkg-patches/5.10/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.10/0013-fedora-rpm.patch
@@ -1,28 +1,53 @@
-# Remove the obsoletes line in kernel-headers
-# Add provides for kernel-devel so there's no conflict
-# and fix akmod-nvidia
-
 diff --git a/scripts/package/mkspec b/scripts/package/mkspec
-index 7c477ca7d..1158f5559 100755
+index 70392fd2f..34f98648f 100755
 --- a/scripts/package/mkspec
 +++ b/scripts/package/mkspec
-@@ -25,0 +26 @@ fi
+@@ -25,7 +25,7 @@ fi
+
 +PROVIDES_DRM=""
-@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+ if grep -q CONFIG_DRM=y .config; then
 -	PROVIDES=kernel-drm
 +	PROVIDES_DRM="Provides: kernel-drm = %{version}"
-@@ -30 +30,0 @@ fi
+ fi
+
 -PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
-@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ __KERNELRELEASE=$(echo $KERNELRELEASE | sed -e "s/-/_/g")
+@@ -50,3 +50,6 @@ sed -e '/^DEL/d' -e 's/^\t*//' <<EOF
+ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
 +	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	# $UTS_MACHINE as a fallback of _arch in case
+@@ -63,4 +66,4 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	Group: Development/System
 -	Obsoletes: kernel-headers
+ 	Provides: kernel-headers = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
+ 	%description headers
+@@ -75,2 +78,5 @@ $S$M	Summary: Development package for building kernel modules to match the $__KE
+ $S$M	Group: System Environment/Kernel
 +$S$M	Provides: kernel-devel = %{version}
 +$S$M	Provides: kernel-devel-uname-r = %{version}
 +$S$M	Provides: installonlypkg(kernel) = %{version}
+ $S$M	AutoReqProv: no
+@@ -80,2 +86,18 @@ $S$M	against the $__KERNELRELEASE kernel package.
+ $S$M
++$S	# Opt out of a lot of Fedora hardening flags etc...
++$S	# See https://src.fedoraproject.org/rpms/redhat-rpm-config//blob/rawhide/f/buildflags.md
++$S	%undefine _package_note_file
++$S	%undefine _auto_set_build_flags
++$S	%undefine _include_frame_pointers
++$S	%define _build_id_flags -Wl,--build-id=none
++$S	%undefine _annotated_build
++$S	%undefine _fortify_level
++$S	%undefine _hardened_build
++$S	%global _lto_cflags %{nil}
++$S	%global _configure_gnuconfig_hack 0
++$S	%global _configure_libtool_hardening_hack 0
++$S	# Nearly had to go to the deep web to find documentation on this one... Gosh
++$S	# See https://github.com/rpm-software-management/rpm/blob/master/macros.in#L471
++$S	%define _build_id_links none
++$S
+ $S	%prep

--- a/linux-tkg-patches/5.11/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.11/0013-fedora-rpm.patch
@@ -1,28 +1,53 @@
-# Remove the obsoletes line in kernel-headers
-# Add provides for kernel-devel so there's no conflict
-# and fix akmod-nvidia
-
 diff --git a/scripts/package/mkspec b/scripts/package/mkspec
-index 7c477ca7d..1158f5559 100755
+index 70392fd2f..34f98648f 100755
 --- a/scripts/package/mkspec
 +++ b/scripts/package/mkspec
-@@ -25,0 +26 @@ fi
+@@ -25,7 +25,7 @@ fi
+
 +PROVIDES_DRM=""
-@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+ if grep -q CONFIG_DRM=y .config; then
 -	PROVIDES=kernel-drm
 +	PROVIDES_DRM="Provides: kernel-drm = %{version}"
-@@ -30 +30,0 @@ fi
+ fi
+
 -PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
-@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ __KERNELRELEASE=$(echo $KERNELRELEASE | sed -e "s/-/_/g")
+@@ -50,3 +50,6 @@ sed -e '/^DEL/d' -e 's/^\t*//' <<EOF
+ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
 +	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	# $UTS_MACHINE as a fallback of _arch in case
+@@ -63,4 +66,4 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	Group: Development/System
 -	Obsoletes: kernel-headers
+ 	Provides: kernel-headers = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
+ 	%description headers
+@@ -75,2 +78,5 @@ $S$M	Summary: Development package for building kernel modules to match the $__KE
+ $S$M	Group: System Environment/Kernel
 +$S$M	Provides: kernel-devel = %{version}
 +$S$M	Provides: kernel-devel-uname-r = %{version}
 +$S$M	Provides: installonlypkg(kernel) = %{version}
+ $S$M	AutoReqProv: no
+@@ -80,2 +86,18 @@ $S$M	against the $__KERNELRELEASE kernel package.
+ $S$M
++$S	# Opt out of a lot of Fedora hardening flags etc...
++$S	# See https://src.fedoraproject.org/rpms/redhat-rpm-config//blob/rawhide/f/buildflags.md
++$S	%undefine _package_note_file
++$S	%undefine _auto_set_build_flags
++$S	%undefine _include_frame_pointers
++$S	%define _build_id_flags -Wl,--build-id=none
++$S	%undefine _annotated_build
++$S	%undefine _fortify_level
++$S	%undefine _hardened_build
++$S	%global _lto_cflags %{nil}
++$S	%global _configure_gnuconfig_hack 0
++$S	%global _configure_libtool_hardening_hack 0
++$S	# Nearly had to go to the deep web to find documentation on this one... Gosh
++$S	# See https://github.com/rpm-software-management/rpm/blob/master/macros.in#L471
++$S	%define _build_id_links none
++$S
+ $S	%prep

--- a/linux-tkg-patches/5.12/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.12/0013-fedora-rpm.patch
@@ -1,28 +1,53 @@
-# Remove the obsoletes line in kernel-headers
-# Add provides for kernel-devel so there's no conflict
-# and fix akmod-nvidia
-
 diff --git a/scripts/package/mkspec b/scripts/package/mkspec
-index 7c477ca7d..1158f5559 100755
+index 70392fd2f..34f98648f 100755
 --- a/scripts/package/mkspec
 +++ b/scripts/package/mkspec
-@@ -25,0 +26 @@ fi
+@@ -25,7 +25,7 @@ fi
+
 +PROVIDES_DRM=""
-@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+ if grep -q CONFIG_DRM=y .config; then
 -	PROVIDES=kernel-drm
 +	PROVIDES_DRM="Provides: kernel-drm = %{version}"
-@@ -30 +30,0 @@ fi
+ fi
+
 -PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
-@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ __KERNELRELEASE=$(echo $KERNELRELEASE | sed -e "s/-/_/g")
+@@ -50,3 +50,6 @@ sed -e '/^DEL/d' -e 's/^\t*//' <<EOF
+ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
 +	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	# $UTS_MACHINE as a fallback of _arch in case
+@@ -63,4 +66,4 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	Group: Development/System
 -	Obsoletes: kernel-headers
+ 	Provides: kernel-headers = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
+ 	%description headers
+@@ -75,2 +78,5 @@ $S$M	Summary: Development package for building kernel modules to match the $__KE
+ $S$M	Group: System Environment/Kernel
 +$S$M	Provides: kernel-devel = %{version}
 +$S$M	Provides: kernel-devel-uname-r = %{version}
 +$S$M	Provides: installonlypkg(kernel) = %{version}
+ $S$M	AutoReqProv: no
+@@ -80,2 +86,18 @@ $S$M	against the $__KERNELRELEASE kernel package.
+ $S$M
++$S	# Opt out of a lot of Fedora hardening flags etc...
++$S	# See https://src.fedoraproject.org/rpms/redhat-rpm-config//blob/rawhide/f/buildflags.md
++$S	%undefine _package_note_file
++$S	%undefine _auto_set_build_flags
++$S	%undefine _include_frame_pointers
++$S	%define _build_id_flags -Wl,--build-id=none
++$S	%undefine _annotated_build
++$S	%undefine _fortify_level
++$S	%undefine _hardened_build
++$S	%global _lto_cflags %{nil}
++$S	%global _configure_gnuconfig_hack 0
++$S	%global _configure_libtool_hardening_hack 0
++$S	# Nearly had to go to the deep web to find documentation on this one... Gosh
++$S	# See https://github.com/rpm-software-management/rpm/blob/master/macros.in#L471
++$S	%define _build_id_links none
++$S
+ $S	%prep

--- a/linux-tkg-patches/5.13/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.13/0013-fedora-rpm.patch
@@ -1,28 +1,53 @@
-# Remove the obsoletes line in kernel-headers
-# Add provides for kernel-devel so there's no conflict
-# and fix akmod-nvidia
-
 diff --git a/scripts/package/mkspec b/scripts/package/mkspec
-index 7c477ca7d..1158f5559 100755
+index 70392fd2f..34f98648f 100755
 --- a/scripts/package/mkspec
 +++ b/scripts/package/mkspec
-@@ -25,0 +26 @@ fi
+@@ -25,7 +25,7 @@ fi
+
 +PROVIDES_DRM=""
-@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+ if grep -q CONFIG_DRM=y .config; then
 -	PROVIDES=kernel-drm
 +	PROVIDES_DRM="Provides: kernel-drm = %{version}"
-@@ -30 +30,0 @@ fi
+ fi
+
 -PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
-@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ __KERNELRELEASE=$(echo $KERNELRELEASE | sed -e "s/-/_/g")
+@@ -50,3 +50,6 @@ sed -e '/^DEL/d' -e 's/^\t*//' <<EOF
+ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
 +	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	# $UTS_MACHINE as a fallback of _arch in case
+@@ -63,4 +66,4 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	Group: Development/System
 -	Obsoletes: kernel-headers
+ 	Provides: kernel-headers = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
+ 	%description headers
+@@ -75,2 +78,5 @@ $S$M	Summary: Development package for building kernel modules to match the $__KE
+ $S$M	Group: System Environment/Kernel
 +$S$M	Provides: kernel-devel = %{version}
 +$S$M	Provides: kernel-devel-uname-r = %{version}
 +$S$M	Provides: installonlypkg(kernel) = %{version}
+ $S$M	AutoReqProv: no
+@@ -80,2 +86,18 @@ $S$M	against the $__KERNELRELEASE kernel package.
+ $S$M
++$S	# Opt out of a lot of Fedora hardening flags etc...
++$S	# See https://src.fedoraproject.org/rpms/redhat-rpm-config//blob/rawhide/f/buildflags.md
++$S	%undefine _package_note_file
++$S	%undefine _auto_set_build_flags
++$S	%undefine _include_frame_pointers
++$S	%define _build_id_flags -Wl,--build-id=none
++$S	%undefine _annotated_build
++$S	%undefine _fortify_level
++$S	%undefine _hardened_build
++$S	%global _lto_cflags %{nil}
++$S	%global _configure_gnuconfig_hack 0
++$S	%global _configure_libtool_hardening_hack 0
++$S	# Nearly had to go to the deep web to find documentation on this one... Gosh
++$S	# See https://github.com/rpm-software-management/rpm/blob/master/macros.in#L471
++$S	%define _build_id_links none
++$S
+ $S	%prep

--- a/linux-tkg-patches/5.14/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.14/0013-fedora-rpm.patch
@@ -1,28 +1,53 @@
-# Remove the obsoletes line in kernel-headers
-# Add provides for kernel-devel so there's no conflict
-# and fix akmod-nvidia
-
 diff --git a/scripts/package/mkspec b/scripts/package/mkspec
-index 7c477ca7d..1158f5559 100755
+index 70392fd2f..34f98648f 100755
 --- a/scripts/package/mkspec
 +++ b/scripts/package/mkspec
-@@ -25,0 +26 @@ fi
+@@ -25,7 +25,7 @@ fi
+
 +PROVIDES_DRM=""
-@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+ if grep -q CONFIG_DRM=y .config; then
 -	PROVIDES=kernel-drm
 +	PROVIDES_DRM="Provides: kernel-drm = %{version}"
-@@ -30 +30,0 @@ fi
+ fi
+
 -PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
-@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ __KERNELRELEASE=$(echo $KERNELRELEASE | sed -e "s/-/_/g")
+@@ -50,3 +50,6 @@ sed -e '/^DEL/d' -e 's/^\t*//' <<EOF
+ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
 +	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	# $UTS_MACHINE as a fallback of _arch in case
+@@ -63,4 +66,4 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	Group: Development/System
 -	Obsoletes: kernel-headers
+ 	Provides: kernel-headers = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
+ 	%description headers
+@@ -75,2 +78,5 @@ $S$M	Summary: Development package for building kernel modules to match the $__KE
+ $S$M	Group: System Environment/Kernel
 +$S$M	Provides: kernel-devel = %{version}
 +$S$M	Provides: kernel-devel-uname-r = %{version}
 +$S$M	Provides: installonlypkg(kernel) = %{version}
+ $S$M	AutoReqProv: no
+@@ -80,2 +86,18 @@ $S$M	against the $__KERNELRELEASE kernel package.
+ $S$M
++$S	# Opt out of a lot of Fedora hardening flags etc...
++$S	# See https://src.fedoraproject.org/rpms/redhat-rpm-config//blob/rawhide/f/buildflags.md
++$S	%undefine _package_note_file
++$S	%undefine _auto_set_build_flags
++$S	%undefine _include_frame_pointers
++$S	%define _build_id_flags -Wl,--build-id=none
++$S	%undefine _annotated_build
++$S	%undefine _fortify_level
++$S	%undefine _hardened_build
++$S	%global _lto_cflags %{nil}
++$S	%global _configure_gnuconfig_hack 0
++$S	%global _configure_libtool_hardening_hack 0
++$S	# Nearly had to go to the deep web to find documentation on this one... Gosh
++$S	# See https://github.com/rpm-software-management/rpm/blob/master/macros.in#L471
++$S	%define _build_id_links none
++$S
+ $S	%prep

--- a/linux-tkg-patches/5.15/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.15/0013-fedora-rpm.patch
@@ -1,28 +1,53 @@
-# Remove the obsoletes line in kernel-headers
-# Add provides for kernel-devel so there's no conflict
-# and fix akmod-nvidia
-
 diff --git a/scripts/package/mkspec b/scripts/package/mkspec
-index 7c477ca7d..1158f5559 100755
+index 70392fd2f..34f98648f 100755
 --- a/scripts/package/mkspec
 +++ b/scripts/package/mkspec
-@@ -25,0 +26 @@ fi
+@@ -25,7 +25,7 @@ fi
+
 +PROVIDES_DRM=""
-@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+ if grep -q CONFIG_DRM=y .config; then
 -	PROVIDES=kernel-drm
 +	PROVIDES_DRM="Provides: kernel-drm = %{version}"
-@@ -30 +30,0 @@ fi
+ fi
+
 -PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
-@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ __KERNELRELEASE=$(echo $KERNELRELEASE | sed -e "s/-/_/g")
+@@ -50,3 +50,6 @@ sed -e '/^DEL/d' -e 's/^\t*//' <<EOF
+ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
 +	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	# $UTS_MACHINE as a fallback of _arch in case
+@@ -63,4 +66,4 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	Group: Development/System
 -	Obsoletes: kernel-headers
+ 	Provides: kernel-headers = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
+ 	%description headers
+@@ -75,2 +78,5 @@ $S$M	Summary: Development package for building kernel modules to match the $__KE
+ $S$M	Group: System Environment/Kernel
 +$S$M	Provides: kernel-devel = %{version}
 +$S$M	Provides: kernel-devel-uname-r = %{version}
 +$S$M	Provides: installonlypkg(kernel) = %{version}
+ $S$M	AutoReqProv: no
+@@ -80,2 +86,18 @@ $S$M	against the $__KERNELRELEASE kernel package.
+ $S$M
++$S	# Opt out of a lot of Fedora hardening flags etc...
++$S	# See https://src.fedoraproject.org/rpms/redhat-rpm-config//blob/rawhide/f/buildflags.md
++$S	%undefine _package_note_file
++$S	%undefine _auto_set_build_flags
++$S	%undefine _include_frame_pointers
++$S	%define _build_id_flags -Wl,--build-id=none
++$S	%undefine _annotated_build
++$S	%undefine _fortify_level
++$S	%undefine _hardened_build
++$S	%global _lto_cflags %{nil}
++$S	%global _configure_gnuconfig_hack 0
++$S	%global _configure_libtool_hardening_hack 0
++$S	# Nearly had to go to the deep web to find documentation on this one... Gosh
++$S	# See https://github.com/rpm-software-management/rpm/blob/master/macros.in#L471
++$S	%define _build_id_links none
++$S
+ $S	%prep

--- a/linux-tkg-patches/5.16/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.16/0013-fedora-rpm.patch
@@ -1,28 +1,53 @@
-# Remove the obsoletes line in kernel-headers
-# Add provides for kernel-devel so there's no conflict
-# and fix akmod-nvidia
-
 diff --git a/scripts/package/mkspec b/scripts/package/mkspec
-index 7c477ca7d..1158f5559 100755
+index 70392fd2f..34f98648f 100755
 --- a/scripts/package/mkspec
 +++ b/scripts/package/mkspec
-@@ -25,0 +26 @@ fi
+@@ -25,7 +25,7 @@ fi
+
 +PROVIDES_DRM=""
-@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+ if grep -q CONFIG_DRM=y .config; then
 -	PROVIDES=kernel-drm
 +	PROVIDES_DRM="Provides: kernel-drm = %{version}"
-@@ -30 +30,0 @@ fi
+ fi
+
 -PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
-@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ __KERNELRELEASE=$(echo $KERNELRELEASE | sed -e "s/-/_/g")
+@@ -50,3 +50,6 @@ sed -e '/^DEL/d' -e 's/^\t*//' <<EOF
+ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
 +	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	# $UTS_MACHINE as a fallback of _arch in case
+@@ -63,4 +66,4 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	Group: Development/System
 -	Obsoletes: kernel-headers
+ 	Provides: kernel-headers = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
+ 	%description headers
+@@ -75,2 +78,5 @@ $S$M	Summary: Development package for building kernel modules to match the $__KE
+ $S$M	Group: System Environment/Kernel
 +$S$M	Provides: kernel-devel = %{version}
 +$S$M	Provides: kernel-devel-uname-r = %{version}
 +$S$M	Provides: installonlypkg(kernel) = %{version}
+ $S$M	AutoReqProv: no
+@@ -80,2 +86,18 @@ $S$M	against the $__KERNELRELEASE kernel package.
+ $S$M
++$S	# Opt out of a lot of Fedora hardening flags etc...
++$S	# See https://src.fedoraproject.org/rpms/redhat-rpm-config//blob/rawhide/f/buildflags.md
++$S	%undefine _package_note_file
++$S	%undefine _auto_set_build_flags
++$S	%undefine _include_frame_pointers
++$S	%define _build_id_flags -Wl,--build-id=none
++$S	%undefine _annotated_build
++$S	%undefine _fortify_level
++$S	%undefine _hardened_build
++$S	%global _lto_cflags %{nil}
++$S	%global _configure_gnuconfig_hack 0
++$S	%global _configure_libtool_hardening_hack 0
++$S	# Nearly had to go to the deep web to find documentation on this one... Gosh
++$S	# See https://github.com/rpm-software-management/rpm/blob/master/macros.in#L471
++$S	%define _build_id_links none
++$S
+ $S	%prep

--- a/linux-tkg-patches/5.17/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.17/0013-fedora-rpm.patch
@@ -1,28 +1,53 @@
-# Remove the obsoletes line in kernel-headers
-# Add provides for kernel-devel so there's no conflict
-# and fix akmod-nvidia
-
 diff --git a/scripts/package/mkspec b/scripts/package/mkspec
-index 7c477ca7d..1158f5559 100755
+index 70392fd2f..34f98648f 100755
 --- a/scripts/package/mkspec
 +++ b/scripts/package/mkspec
-@@ -25,0 +26 @@ fi
+@@ -25,7 +25,7 @@ fi
+
 +PROVIDES_DRM=""
-@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+ if grep -q CONFIG_DRM=y .config; then
 -	PROVIDES=kernel-drm
 +	PROVIDES_DRM="Provides: kernel-drm = %{version}"
-@@ -30 +30,0 @@ fi
+ fi
+
 -PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
-@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ __KERNELRELEASE=$(echo $KERNELRELEASE | sed -e "s/-/_/g")
+@@ -50,3 +50,6 @@ sed -e '/^DEL/d' -e 's/^\t*//' <<EOF
+ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
 +	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	# $UTS_MACHINE as a fallback of _arch in case
+@@ -63,4 +66,4 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	Group: Development/System
 -	Obsoletes: kernel-headers
+ 	Provides: kernel-headers = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
+ 	%description headers
+@@ -75,2 +78,5 @@ $S$M	Summary: Development package for building kernel modules to match the $__KE
+ $S$M	Group: System Environment/Kernel
 +$S$M	Provides: kernel-devel = %{version}
 +$S$M	Provides: kernel-devel-uname-r = %{version}
 +$S$M	Provides: installonlypkg(kernel) = %{version}
+ $S$M	AutoReqProv: no
+@@ -80,2 +86,18 @@ $S$M	against the $__KERNELRELEASE kernel package.
+ $S$M
++$S	# Opt out of a lot of Fedora hardening flags etc...
++$S	# See https://src.fedoraproject.org/rpms/redhat-rpm-config//blob/rawhide/f/buildflags.md
++$S	%undefine _package_note_file
++$S	%undefine _auto_set_build_flags
++$S	%undefine _include_frame_pointers
++$S	%define _build_id_flags -Wl,--build-id=none
++$S	%undefine _annotated_build
++$S	%undefine _fortify_level
++$S	%undefine _hardened_build
++$S	%global _lto_cflags %{nil}
++$S	%global _configure_gnuconfig_hack 0
++$S	%global _configure_libtool_hardening_hack 0
++$S	# Nearly had to go to the deep web to find documentation on this one... Gosh
++$S	# See https://github.com/rpm-software-management/rpm/blob/master/macros.in#L471
++$S	%define _build_id_links none
++$S
+ $S	%prep

--- a/linux-tkg-patches/5.18/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.18/0013-fedora-rpm.patch
@@ -1,27 +1,53 @@
-# Remove the obsoletes line in kernel-headers
-# Add provides for kernel-devel so there's no conflict
-
 diff --git a/scripts/package/mkspec b/scripts/package/mkspec
-index 7c477ca7d..1158f5559 100755
+index 70392fd2f..34f98648f 100755
 --- a/scripts/package/mkspec
 +++ b/scripts/package/mkspec
-@@ -25,0 +26 @@ fi
+@@ -25,7 +25,7 @@ fi
+
 +PROVIDES_DRM=""
-@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+ if grep -q CONFIG_DRM=y .config; then
 -	PROVIDES=kernel-drm
 +	PROVIDES_DRM="Provides: kernel-drm = %{version}"
-@@ -30 +30,0 @@ fi
+ fi
+
 -PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
-@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ __KERNELRELEASE=$(echo $KERNELRELEASE | sed -e "s/-/_/g")
+@@ -50,3 +50,6 @@ sed -e '/^DEL/d' -e 's/^\t*//' <<EOF
+ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
 +	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	# $UTS_MACHINE as a fallback of _arch in case
+@@ -63,4 +66,4 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	Group: Development/System
 -	Obsoletes: kernel-headers
+ 	Provides: kernel-headers = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
+ 	%description headers
+@@ -75,2 +78,5 @@ $S$M	Summary: Development package for building kernel modules to match the $__KE
+ $S$M	Group: System Environment/Kernel
 +$S$M	Provides: kernel-devel = %{version}
 +$S$M	Provides: kernel-devel-uname-r = %{version}
 +$S$M	Provides: installonlypkg(kernel) = %{version}
+ $S$M	AutoReqProv: no
+@@ -80,2 +86,18 @@ $S$M	against the $__KERNELRELEASE kernel package.
+ $S$M
++$S	# Opt out of a lot of Fedora hardening flags etc...
++$S	# See https://src.fedoraproject.org/rpms/redhat-rpm-config//blob/rawhide/f/buildflags.md
++$S	%undefine _package_note_file
++$S	%undefine _auto_set_build_flags
++$S	%undefine _include_frame_pointers
++$S	%define _build_id_flags -Wl,--build-id=none
++$S	%undefine _annotated_build
++$S	%undefine _fortify_level
++$S	%undefine _hardened_build
++$S	%global _lto_cflags %{nil}
++$S	%global _configure_gnuconfig_hack 0
++$S	%global _configure_libtool_hardening_hack 0
++$S	# Nearly had to go to the deep web to find documentation on this one... Gosh
++$S	# See https://github.com/rpm-software-management/rpm/blob/master/macros.in#L471
++$S	%define _build_id_links none
++$S
+ $S	%prep

--- a/linux-tkg-patches/5.19/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.19/0013-fedora-rpm.patch
@@ -1,27 +1,53 @@
-# Remove the obsoletes line in kernel-headers
-# Add provides for kernel-devel so there's no conflict
-
 diff --git a/scripts/package/mkspec b/scripts/package/mkspec
-index 7c477ca7d..1158f5559 100755
+index 70392fd2f..34f98648f 100755
 --- a/scripts/package/mkspec
 +++ b/scripts/package/mkspec
-@@ -25,0 +26 @@ fi
+@@ -25,7 +25,7 @@ fi
+
 +PROVIDES_DRM=""
-@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+ if grep -q CONFIG_DRM=y .config; then
 -	PROVIDES=kernel-drm
 +	PROVIDES_DRM="Provides: kernel-drm = %{version}"
-@@ -30 +30,0 @@ fi
+ fi
+
 -PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
-@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ __KERNELRELEASE=$(echo $KERNELRELEASE | sed -e "s/-/_/g")
+@@ -50,3 +50,6 @@ sed -e '/^DEL/d' -e 's/^\t*//' <<EOF
+ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
 +	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	# $UTS_MACHINE as a fallback of _arch in case
+@@ -63,4 +66,4 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	Group: Development/System
 -	Obsoletes: kernel-headers
+ 	Provides: kernel-headers = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
+ 	%description headers
+@@ -75,2 +78,5 @@ $S$M	Summary: Development package for building kernel modules to match the $__KE
+ $S$M	Group: System Environment/Kernel
 +$S$M	Provides: kernel-devel = %{version}
 +$S$M	Provides: kernel-devel-uname-r = %{version}
 +$S$M	Provides: installonlypkg(kernel) = %{version}
+ $S$M	AutoReqProv: no
+@@ -80,2 +86,18 @@ $S$M	against the $__KERNELRELEASE kernel package.
+ $S$M
++$S	# Opt out of a lot of Fedora hardening flags etc...
++$S	# See https://src.fedoraproject.org/rpms/redhat-rpm-config//blob/rawhide/f/buildflags.md
++$S	%undefine _package_note_file
++$S	%undefine _auto_set_build_flags
++$S	%undefine _include_frame_pointers
++$S	%define _build_id_flags -Wl,--build-id=none
++$S	%undefine _annotated_build
++$S	%undefine _fortify_level
++$S	%undefine _hardened_build
++$S	%global _lto_cflags %{nil}
++$S	%global _configure_gnuconfig_hack 0
++$S	%global _configure_libtool_hardening_hack 0
++$S	# Nearly had to go to the deep web to find documentation on this one... Gosh
++$S	# See https://github.com/rpm-software-management/rpm/blob/master/macros.in#L471
++$S	%define _build_id_links none
++$S
+ $S	%prep

--- a/linux-tkg-patches/5.4/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.4/0013-fedora-rpm.patch
@@ -1,28 +1,53 @@
-# Remove the obsoletes line in kernel-headers
-# Add provides for kernel-devel so there's no conflict
-# and fix akmod-nvidia
-
 diff --git a/scripts/package/mkspec b/scripts/package/mkspec
-index 7c477ca7d..1158f5559 100755
+index 70392fd2f..34f98648f 100755
 --- a/scripts/package/mkspec
 +++ b/scripts/package/mkspec
-@@ -25,0 +26 @@ fi
+@@ -25,7 +25,7 @@ fi
+
 +PROVIDES_DRM=""
-@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+ if grep -q CONFIG_DRM=y .config; then
 -	PROVIDES=kernel-drm
 +	PROVIDES_DRM="Provides: kernel-drm = %{version}"
-@@ -30 +30,0 @@ fi
+ fi
+
 -PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
-@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ __KERNELRELEASE=$(echo $KERNELRELEASE | sed -e "s/-/_/g")
+@@ -50,3 +50,6 @@ sed -e '/^DEL/d' -e 's/^\t*//' <<EOF
+ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
 +	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	# $UTS_MACHINE as a fallback of _arch in case
+@@ -63,4 +66,4 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	Group: Development/System
 -	Obsoletes: kernel-headers
+ 	Provides: kernel-headers = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
+ 	%description headers
+@@ -75,2 +78,5 @@ $S$M	Summary: Development package for building kernel modules to match the $__KE
+ $S$M	Group: System Environment/Kernel
 +$S$M	Provides: kernel-devel = %{version}
 +$S$M	Provides: kernel-devel-uname-r = %{version}
 +$S$M	Provides: installonlypkg(kernel) = %{version}
+ $S$M	AutoReqProv: no
+@@ -80,2 +86,18 @@ $S$M	against the $__KERNELRELEASE kernel package.
+ $S$M
++$S	# Opt out of a lot of Fedora hardening flags etc...
++$S	# See https://src.fedoraproject.org/rpms/redhat-rpm-config//blob/rawhide/f/buildflags.md
++$S	%undefine _package_note_file
++$S	%undefine _auto_set_build_flags
++$S	%undefine _include_frame_pointers
++$S	%define _build_id_flags -Wl,--build-id=none
++$S	%undefine _annotated_build
++$S	%undefine _fortify_level
++$S	%undefine _hardened_build
++$S	%global _lto_cflags %{nil}
++$S	%global _configure_gnuconfig_hack 0
++$S	%global _configure_libtool_hardening_hack 0
++$S	# Nearly had to go to the deep web to find documentation on this one... Gosh
++$S	# See https://github.com/rpm-software-management/rpm/blob/master/macros.in#L471
++$S	%define _build_id_links none
++$S
+ $S	%prep

--- a/linux-tkg-patches/5.7/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.7/0013-fedora-rpm.patch
@@ -1,28 +1,53 @@
-# Remove the obsoletes line in kernel-headers
-# Add provides for kernel-devel so there's no conflict
-# and fix akmod-nvidia
-
 diff --git a/scripts/package/mkspec b/scripts/package/mkspec
-index 7c477ca7d..1158f5559 100755
+index 70392fd2f..34f98648f 100755
 --- a/scripts/package/mkspec
 +++ b/scripts/package/mkspec
-@@ -25,0 +26 @@ fi
+@@ -25,7 +25,7 @@ fi
+
 +PROVIDES_DRM=""
-@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+ if grep -q CONFIG_DRM=y .config; then
 -	PROVIDES=kernel-drm
 +	PROVIDES_DRM="Provides: kernel-drm = %{version}"
-@@ -30 +30,0 @@ fi
+ fi
+
 -PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
-@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ __KERNELRELEASE=$(echo $KERNELRELEASE | sed -e "s/-/_/g")
+@@ -50,3 +50,6 @@ sed -e '/^DEL/d' -e 's/^\t*//' <<EOF
+ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
 +	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	# $UTS_MACHINE as a fallback of _arch in case
+@@ -63,4 +66,4 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	Group: Development/System
 -	Obsoletes: kernel-headers
+ 	Provides: kernel-headers = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
+ 	%description headers
+@@ -75,2 +78,5 @@ $S$M	Summary: Development package for building kernel modules to match the $__KE
+ $S$M	Group: System Environment/Kernel
 +$S$M	Provides: kernel-devel = %{version}
 +$S$M	Provides: kernel-devel-uname-r = %{version}
 +$S$M	Provides: installonlypkg(kernel) = %{version}
+ $S$M	AutoReqProv: no
+@@ -80,2 +86,18 @@ $S$M	against the $__KERNELRELEASE kernel package.
+ $S$M
++$S	# Opt out of a lot of Fedora hardening flags etc...
++$S	# See https://src.fedoraproject.org/rpms/redhat-rpm-config//blob/rawhide/f/buildflags.md
++$S	%undefine _package_note_file
++$S	%undefine _auto_set_build_flags
++$S	%undefine _include_frame_pointers
++$S	%define _build_id_flags -Wl,--build-id=none
++$S	%undefine _annotated_build
++$S	%undefine _fortify_level
++$S	%undefine _hardened_build
++$S	%global _lto_cflags %{nil}
++$S	%global _configure_gnuconfig_hack 0
++$S	%global _configure_libtool_hardening_hack 0
++$S	# Nearly had to go to the deep web to find documentation on this one... Gosh
++$S	# See https://github.com/rpm-software-management/rpm/blob/master/macros.in#L471
++$S	%define _build_id_links none
++$S
+ $S	%prep

--- a/linux-tkg-patches/5.8/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.8/0013-fedora-rpm.patch
@@ -1,28 +1,53 @@
-# Remove the obsoletes line in kernel-headers
-# Add provides for kernel-devel so there's no conflict
-# and fix akmod-nvidia
-
 diff --git a/scripts/package/mkspec b/scripts/package/mkspec
-index 7c477ca7d..1158f5559 100755
+index 70392fd2f..34f98648f 100755
 --- a/scripts/package/mkspec
 +++ b/scripts/package/mkspec
-@@ -25,0 +26 @@ fi
+@@ -25,7 +25,7 @@ fi
+
 +PROVIDES_DRM=""
-@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+ if grep -q CONFIG_DRM=y .config; then
 -	PROVIDES=kernel-drm
 +	PROVIDES_DRM="Provides: kernel-drm = %{version}"
-@@ -30 +30,0 @@ fi
+ fi
+
 -PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
-@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ __KERNELRELEASE=$(echo $KERNELRELEASE | sed -e "s/-/_/g")
+@@ -50,3 +50,6 @@ sed -e '/^DEL/d' -e 's/^\t*//' <<EOF
+ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
 +	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	# $UTS_MACHINE as a fallback of _arch in case
+@@ -63,4 +66,4 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	Group: Development/System
 -	Obsoletes: kernel-headers
+ 	Provides: kernel-headers = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
+ 	%description headers
+@@ -75,2 +78,5 @@ $S$M	Summary: Development package for building kernel modules to match the $__KE
+ $S$M	Group: System Environment/Kernel
 +$S$M	Provides: kernel-devel = %{version}
 +$S$M	Provides: kernel-devel-uname-r = %{version}
 +$S$M	Provides: installonlypkg(kernel) = %{version}
+ $S$M	AutoReqProv: no
+@@ -80,2 +86,18 @@ $S$M	against the $__KERNELRELEASE kernel package.
+ $S$M
++$S	# Opt out of a lot of Fedora hardening flags etc...
++$S	# See https://src.fedoraproject.org/rpms/redhat-rpm-config//blob/rawhide/f/buildflags.md
++$S	%undefine _package_note_file
++$S	%undefine _auto_set_build_flags
++$S	%undefine _include_frame_pointers
++$S	%define _build_id_flags -Wl,--build-id=none
++$S	%undefine _annotated_build
++$S	%undefine _fortify_level
++$S	%undefine _hardened_build
++$S	%global _lto_cflags %{nil}
++$S	%global _configure_gnuconfig_hack 0
++$S	%global _configure_libtool_hardening_hack 0
++$S	# Nearly had to go to the deep web to find documentation on this one... Gosh
++$S	# See https://github.com/rpm-software-management/rpm/blob/master/macros.in#L471
++$S	%define _build_id_links none
++$S
+ $S	%prep

--- a/linux-tkg-patches/5.9/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/5.9/0013-fedora-rpm.patch
@@ -1,28 +1,53 @@
-# Remove the obsoletes line in kernel-headers
-# Add provides for kernel-devel so there's no conflict
-# and fix akmod-nvidia
-
 diff --git a/scripts/package/mkspec b/scripts/package/mkspec
-index 7c477ca7d..1158f5559 100755
+index 70392fd2f..34f98648f 100755
 --- a/scripts/package/mkspec
 +++ b/scripts/package/mkspec
-@@ -25,0 +26 @@ fi
+@@ -25,7 +25,7 @@ fi
+
 +PROVIDES_DRM=""
-@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+ if grep -q CONFIG_DRM=y .config; then
 -	PROVIDES=kernel-drm
 +	PROVIDES_DRM="Provides: kernel-drm = %{version}"
-@@ -30 +30,0 @@ fi
+ fi
+
 -PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
-@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ __KERNELRELEASE=$(echo $KERNELRELEASE | sed -e "s/-/_/g")
+@@ -50,3 +50,6 @@ sed -e '/^DEL/d' -e 's/^\t*//' <<EOF
+ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
 +	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	# $UTS_MACHINE as a fallback of _arch in case
+@@ -63,4 +66,4 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	Group: Development/System
 -	Obsoletes: kernel-headers
+ 	Provides: kernel-headers = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
+ 	%description headers
+@@ -75,2 +78,5 @@ $S$M	Summary: Development package for building kernel modules to match the $__KE
+ $S$M	Group: System Environment/Kernel
 +$S$M	Provides: kernel-devel = %{version}
 +$S$M	Provides: kernel-devel-uname-r = %{version}
 +$S$M	Provides: installonlypkg(kernel) = %{version}
+ $S$M	AutoReqProv: no
+@@ -80,2 +86,18 @@ $S$M	against the $__KERNELRELEASE kernel package.
+ $S$M
++$S	# Opt out of a lot of Fedora hardening flags etc...
++$S	# See https://src.fedoraproject.org/rpms/redhat-rpm-config//blob/rawhide/f/buildflags.md
++$S	%undefine _package_note_file
++$S	%undefine _auto_set_build_flags
++$S	%undefine _include_frame_pointers
++$S	%define _build_id_flags -Wl,--build-id=none
++$S	%undefine _annotated_build
++$S	%undefine _fortify_level
++$S	%undefine _hardened_build
++$S	%global _lto_cflags %{nil}
++$S	%global _configure_gnuconfig_hack 0
++$S	%global _configure_libtool_hardening_hack 0
++$S	# Nearly had to go to the deep web to find documentation on this one... Gosh
++$S	# See https://github.com/rpm-software-management/rpm/blob/master/macros.in#L471
++$S	%define _build_id_links none
++$S
+ $S	%prep

--- a/linux-tkg-patches/6.0/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/6.0/0013-fedora-rpm.patch
@@ -1,27 +1,53 @@
-# Remove the obsoletes line in kernel-headers
-# Add provides for kernel-devel so there's no conflict
-
 diff --git a/scripts/package/mkspec b/scripts/package/mkspec
-index 7c477ca7d..1158f5559 100755
+index 70392fd2f..34f98648f 100755
 --- a/scripts/package/mkspec
 +++ b/scripts/package/mkspec
-@@ -25,0 +26 @@ fi
+@@ -25,7 +25,7 @@ fi
+
 +PROVIDES_DRM=""
-@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+ if grep -q CONFIG_DRM=y .config; then
 -	PROVIDES=kernel-drm
 +	PROVIDES_DRM="Provides: kernel-drm = %{version}"
-@@ -30 +30,0 @@ fi
+ fi
+
 -PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
-@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ __KERNELRELEASE=$(echo $KERNELRELEASE | sed -e "s/-/_/g")
+@@ -50,3 +50,6 @@ sed -e '/^DEL/d' -e 's/^\t*//' <<EOF
+ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
 +	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	# $UTS_MACHINE as a fallback of _arch in case
+@@ -63,4 +66,4 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	Group: Development/System
 -	Obsoletes: kernel-headers
+ 	Provides: kernel-headers = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
+ 	%description headers
+@@ -75,2 +78,5 @@ $S$M	Summary: Development package for building kernel modules to match the $__KE
+ $S$M	Group: System Environment/Kernel
 +$S$M	Provides: kernel-devel = %{version}
 +$S$M	Provides: kernel-devel-uname-r = %{version}
 +$S$M	Provides: installonlypkg(kernel) = %{version}
+ $S$M	AutoReqProv: no
+@@ -80,2 +86,18 @@ $S$M	against the $__KERNELRELEASE kernel package.
+ $S$M
++$S	# Opt out of a lot of Fedora hardening flags etc...
++$S	# See https://src.fedoraproject.org/rpms/redhat-rpm-config//blob/rawhide/f/buildflags.md
++$S	%undefine _package_note_file
++$S	%undefine _auto_set_build_flags
++$S	%undefine _include_frame_pointers
++$S	%define _build_id_flags -Wl,--build-id=none
++$S	%undefine _annotated_build
++$S	%undefine _fortify_level
++$S	%undefine _hardened_build
++$S	%global _lto_cflags %{nil}
++$S	%global _configure_gnuconfig_hack 0
++$S	%global _configure_libtool_hardening_hack 0
++$S	# Nearly had to go to the deep web to find documentation on this one... Gosh
++$S	# See https://github.com/rpm-software-management/rpm/blob/master/macros.in#L471
++$S	%define _build_id_links none
++$S
+ $S	%prep

--- a/linux-tkg-patches/6.1/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/6.1/0013-fedora-rpm.patch
@@ -1,27 +1,53 @@
-# Remove the obsoletes line in kernel-headers
-# Add provides for kernel-devel so there's no conflict
-
 diff --git a/scripts/package/mkspec b/scripts/package/mkspec
-index 7c477ca7d..1158f5559 100755
+index 70392fd2f..34f98648f 100755
 --- a/scripts/package/mkspec
 +++ b/scripts/package/mkspec
-@@ -25,0 +26 @@ fi
+@@ -25,7 +25,7 @@ fi
+
 +PROVIDES_DRM=""
-@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+ if grep -q CONFIG_DRM=y .config; then
 -	PROVIDES=kernel-drm
 +	PROVIDES_DRM="Provides: kernel-drm = %{version}"
-@@ -30 +30,0 @@ fi
+ fi
+
 -PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
-@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ __KERNELRELEASE=$(echo $KERNELRELEASE | sed -e "s/-/_/g")
+@@ -50,3 +50,6 @@ sed -e '/^DEL/d' -e 's/^\t*//' <<EOF
+ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
 +	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	# $UTS_MACHINE as a fallback of _arch in case
+@@ -63,4 +66,4 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	Group: Development/System
 -	Obsoletes: kernel-headers
+ 	Provides: kernel-headers = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
+ 	%description headers
+@@ -75,2 +78,5 @@ $S$M	Summary: Development package for building kernel modules to match the $__KE
+ $S$M	Group: System Environment/Kernel
 +$S$M	Provides: kernel-devel = %{version}
 +$S$M	Provides: kernel-devel-uname-r = %{version}
 +$S$M	Provides: installonlypkg(kernel) = %{version}
+ $S$M	AutoReqProv: no
+@@ -80,2 +86,18 @@ $S$M	against the $__KERNELRELEASE kernel package.
+ $S$M
++$S	# Opt out of a lot of Fedora hardening flags etc...
++$S	# See https://src.fedoraproject.org/rpms/redhat-rpm-config//blob/rawhide/f/buildflags.md
++$S	%undefine _package_note_file
++$S	%undefine _auto_set_build_flags
++$S	%undefine _include_frame_pointers
++$S	%define _build_id_flags -Wl,--build-id=none
++$S	%undefine _annotated_build
++$S	%undefine _fortify_level
++$S	%undefine _hardened_build
++$S	%global _lto_cflags %{nil}
++$S	%global _configure_gnuconfig_hack 0
++$S	%global _configure_libtool_hardening_hack 0
++$S	# Nearly had to go to the deep web to find documentation on this one... Gosh
++$S	# See https://github.com/rpm-software-management/rpm/blob/master/macros.in#L471
++$S	%define _build_id_links none
++$S
+ $S	%prep

--- a/linux-tkg-patches/6.2/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/6.2/0013-fedora-rpm.patch
@@ -1,27 +1,53 @@
-# Remove the obsoletes line in kernel-headers
-# Add provides for kernel-devel so there's no conflict
-
 diff --git a/scripts/package/mkspec b/scripts/package/mkspec
-index 7c477ca7d..1158f5559 100755
+index 70392fd2f..34f98648f 100755
 --- a/scripts/package/mkspec
 +++ b/scripts/package/mkspec
-@@ -25,0 +26 @@ fi
+@@ -25,7 +25,7 @@ fi
+
 +PROVIDES_DRM=""
-@@ -27 +28 @@ if grep -q CONFIG_DRM=y .config; then
+ if grep -q CONFIG_DRM=y .config; then
 -	PROVIDES=kernel-drm
 +	PROVIDES_DRM="Provides: kernel-drm = %{version}"
-@@ -30 +30,0 @@ fi
+ fi
+
 -PROVIDES="$PROVIDES kernel-$KERNELRELEASE"
-@@ -51 +51,3 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ __KERNELRELEASE=$(echo $KERNELRELEASE | sed -e "s/-/_/g")
+@@ -50,3 +50,6 @@ sed -e '/^DEL/d' -e 's/^\t*//' <<EOF
+ $S	Source: kernel-$__KERNELRELEASE.tar.gz
 -	Provides: $PROVIDES
 +	$PROVIDES_DRM
 +	Provides: kernel = %{version}
 +	Provides: kernel-uname-r = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -61 +63 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	# $UTS_MACHINE as a fallback of _arch in case
+@@ -63,4 +66,4 @@ $S	Source: kernel-$__KERNELRELEASE.tar.gz
+ 	Group: Development/System
 -	Obsoletes: kernel-headers
+ 	Provides: kernel-headers = %{version}
 +	Provides: installonlypkg(kernel) = %{version}
-@@ -72,0 +75,3 @@ $S$M	Group: System Environment/Kernel
+ 	%description headers
+@@ -75,2 +78,5 @@ $S$M	Summary: Development package for building kernel modules to match the $__KE
+ $S$M	Group: System Environment/Kernel
 +$S$M	Provides: kernel-devel = %{version}
 +$S$M	Provides: kernel-devel-uname-r = %{version}
 +$S$M	Provides: installonlypkg(kernel) = %{version}
+ $S$M	AutoReqProv: no
+@@ -80,2 +86,18 @@ $S$M	against the $__KERNELRELEASE kernel package.
+ $S$M
++$S	# Opt out of a lot of Fedora hardening flags etc...
++$S	# See https://src.fedoraproject.org/rpms/redhat-rpm-config//blob/rawhide/f/buildflags.md
++$S	%undefine _package_note_file
++$S	%undefine _auto_set_build_flags
++$S	%undefine _include_frame_pointers
++$S	%define _build_id_flags -Wl,--build-id=none
++$S	%undefine _annotated_build
++$S	%undefine _fortify_level
++$S	%undefine _hardened_build
++$S	%global _lto_cflags %{nil}
++$S	%global _configure_gnuconfig_hack 0
++$S	%global _configure_libtool_hardening_hack 0
++$S	# Nearly had to go to the deep web to find documentation on this one... Gosh
++$S	# See https://github.com/rpm-software-management/rpm/blob/master/macros.in#L471
++$S	%define _build_id_links none
++$S
+ $S	%prep


### PR DESCRIPTION
While trying to fix the `mkspec` script within the kernel, I discovered a few things
- Fedora imposes various hardening flags and other bloat that we could avoid, 
- Fedora produces some debug files that conflict with other `tkg` kernels

It took me some time to find documentation to disable all that, but it's done. There also was mistake in the `install.sh` where I was using the wrong work dir path variable, people shouldn't have been able to build for Fedora without giving absolute paths since we merged the work dir change MR.

Adel