### PR TITLE
linux 6.{2,3}.y: Fix wrong patch

### DIFF
--- a/linux-tkg-patches/6.2/0003-glitched-cfs-additions.patch
+++ b/linux-tkg-patches/6.2/0003-glitched-cfs-additions.patch
@@ -17,6 +17,9 @@ index 6b3b59cc51d6..2a0072192c3d 100644
  
  const_debug unsigned int sysctl_sched_migration_cost	= 500000UL;
 +#endif
+
+ int sched_thermal_decay_shift;
+ static int __init setup_sched_thermal_decay_shift(char *str)
  
 diff --git a/kernel/sched/topology.c b/kernel/sched/topology.c
 index 051aaf65c..705df5511 100644
@@ -31,5 +34,3 @@ index 051aaf65c..705df5511 100644
  DEFINE_MUTEX(sched_energy_mutex);
  bool sched_energy_update;
 
---
-2.39.1

--- a/linux-tkg-patches/6.3/0003-glitched-cfs-additions.patch
+++ b/linux-tkg-patches/6.3/0003-glitched-cfs-additions.patch
@@ -17,6 +17,9 @@ index 6b3b59cc51d6..2a0072192c3d 100644
  
  const_debug unsigned int sysctl_sched_migration_cost	= 500000UL;
 +#endif
+
+ int sched_thermal_decay_shift;
+ static int __init setup_sched_thermal_decay_shift(char *str)
  
 diff --git a/kernel/sched/topology.c b/kernel/sched/topology.c
 index 051aaf65c..705df5511 100644
@@ -31,5 +34,3 @@ index 051aaf65c..705df5511 100644
  DEFINE_MUTEX(sched_energy_mutex);
  bool sched_energy_update;
 
---
-2.39.1


### PR DESCRIPTION
Sorry, I should have checked the changes more thoroughly before pushing.