### PR TITLE
Remove anbox option

### DIFF
--- a/.github/workflows/build-current-kernel-arch.yml
+++ b/.github/workflows/build-current-kernel-arch.yml
@@ -6,7 +6,6 @@ on:
 
 
 env:
-  _anbox: "true"
   _processor_opt: "generic"
   PKGDEST: "/tmp/linux-tkg"
   _debugdisable: "true"

--- a/.github/workflows/build-current-kernel-arch.yml
+++ b/.github/workflows/build-current-kernel-arch.yml
@@ -6,6 +6,7 @@ on:
 
 
 env:
+  _waydroid: "true"
   _processor_opt: "generic"
   PKGDEST: "/tmp/linux-tkg"
   _debugdisable: "true"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ The `customization.cfg` file offers many toggles for extra tweaks:
 - Using [Modprobed-db](https://github.com/graysky2/modprobed-db)'s database can reduce the compilation time and produce a smaller kernel which will only contain the modules listed in it. **NOT recommended**
   - **Warning**: make sure to read [thoroughly about it first](https://wiki.archlinux.org/index.php/Modprobed-db) since it comes with caveats that can lead to an unbootable kernel.
 - "Zenify" patchset using core blk, mm and scheduler tweaks from Zen
-- [Anbox](https://wiki.archlinux.org/title/Anbox) support (See [Anbox usage](https://github.com/Frogging-Family/linux-tkg#anbox-usage))
 - `ZFS` FPU symbols (<5.9)
 - Overrides for missing ACS capabilities
 - Provide own kernel `.config` file
@@ -51,38 +50,6 @@ The `customization.cfg` file offers many toggles for extra tweaks:
 #### User patches
 
 To apply your own patch files using the provided scripts, you will need to put them in a `linux5y-tkg-userpatches` folder -- `y` needs to be changed with the kernel version the patch works on, _e.g_ `linux510-tkg-userpatches` -- at the same level as the `PKGBUILD` file, with the `.mypatch` extension. The script will by default ask if you want to apply them, one by one. The option `_user_patches` should be set to `true` in the `customization.cfg` file for this to work.
-
-#### Anbox usage
-
-**As of kernel 5.18, ashmem was dropped, breaking anbox. Their old Android 7 base doesn't allow moving to memfd so it might take a while to fix. The newer WayDroid alternative moved to using memfd thanks to an easier to work with Android 10 base. It still depends on binderfs, which is supported on 5.18+, but ashmem isn't a requirement for it anymore. An ashmem dkms driver can be used to circumvent the issue, but it currently is problematic on 5.19 and is likely to require active maintenance going forward. If you can, consider moving to WayDroid.**
-
-When enabling the anbox support option, the `binder` and `ashmem` modules are built-in. You don't have to load them. However you'll need to mount binderfs :
-```shell
-sudo mkdir /dev/binderfs
-sudo mount -t binder binder /dev/binderfs
-```
-
-To make this persistent, you can create `/etc/tmpfiles.d/anbox.conf` with the following content :
-```
-d! /dev/binderfs 0755 root root
-```
-After which you can add the following to your `/etc/fstab` :
-```
-binder                         /dev/binderfs binder   nofail  0      0
-```
-
-Then, if needed, start the anbox service :
-```shell
-systemctl start anbox-container-manager.service
-```
-
-You can also enable the service for it to be auto-started on boot :
-```shell
-systemctl enable anbox-container-manager.service
-```
-
-You're set to run Anbox.
-If you prefer automatic setup you can install `anbox-support` from AUR which will take care of everything by itself.
 
 
 ### Install procedure

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The `customization.cfg` file offers many toggles for extra tweaks:
 - "Zenify" patchset using core blk, mm and scheduler tweaks from Zen
 - `ZFS` FPU symbols (<5.9)
 - Overrides for missing ACS capabilities
+- [Waydroid](https://wiki.archlinux.org/title/Waydroid) support
 - Provide own kernel `.config` file
 - ...
 #### User patches

--- a/customization.cfg
+++ b/customization.cfg
@@ -168,6 +168,9 @@ _bcachefs="false"
 # ! Can't be used on multiple kernels installed side-by-side, which will require https://aur.archlinux.org/packages/winesync-dkms/ instead of this option !
 _winesync="false"
 
+# Set to "true" to enable Binder modules to use Waydroid Android containers
+_waydroid=""
+
 # A selection of patches from Zen/Liquorix kernel and additional tweaks for a better gaming experience (ZENIFY) - Default is "true"
 _zenify="true"
 

--- a/customization.cfg
+++ b/customization.cfg
@@ -168,9 +168,6 @@ _bcachefs="false"
 # ! Can't be used on multiple kernels installed side-by-side, which will require https://aur.archlinux.org/packages/winesync-dkms/ instead of this option !
 _winesync="false"
 
-# Set to "true" to enable Binder and Ashmem, the kernel modules required to use the android emulator Anbox. ! This doesn't apply to 5.4.y !
-_anbox=""
-
 # A selection of patches from Zen/Liquorix kernel and additional tweaks for a better gaming experience (ZENIFY) - Default is "true"
 _zenify="true"
 

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -1591,25 +1591,6 @@ CONFIG_DEBUG_INFO_BTF_MODULES=y\r
   unset tkgpatch
   unset _msg
 
-  # Anbox modules
-  if [ "$_basever" != "504" ]; then
-    if [ -z "$_anbox" ]; then
-      plain ""
-      plain "Enable android modules for use with Anbox?"
-      plain "https://github.com/anbox/anbox"
-      read -rp "`echo $'    > N/y : '`" CONDITION12;
-    fi
-    if [[ "$CONDITION12" =~ [yY] ]] || [ "$_anbox" = "true" ]; then
-      _enable "ASHMEM" "ION" "ION_CMA_HEAP" "ANDROID" "ANDROID_BINDER_IPC" "ANDROID_BINDERFS"
-      _disable "ION_SYSTEM_HEAP" "ANDROID_BINDER_IPC_SELFTEST"
-      scripts/config --set-str "ANDROID_BINDER_DEVICES" "binder,hwbinder,vndbinder"
-      warning "Please make sure to read up on how to use this; https://github.com/Frogging-Family/linux-tkg#anbox-usage"
-      if [[ "$CONDITION12" =~ [yY] ]]; then
-        read -rp "Press enter to continue..."
-      fi
-    fi
-  fi
-
   # NR_CPUS
   if [ "$_basever" != "601" ]; then
     if [ -n "$_NR_CPUS_value" ]; then

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -1591,6 +1591,22 @@ CONFIG_DEBUG_INFO_BTF_MODULES=y\r
   unset tkgpatch
   unset _msg
 
+  # Waydroid
+  if [ -z "$_waydroid" ]; then
+    plain ""
+    plain "Enable android modules for use with Waydroid?"
+    plain "https://waydro.id"
+    read -rp "`echo $'    > N/y : '`" CONDITION12;
+  fi
+  if [[ "$CONDITION12" =~ [yY] ]] || [ "$_waydroid" = "true" ]; then
+    _enable "ANDROID" "ANDROID_BINDER_IPC" "ANDROID_BINDERFS"
+    _disable "ANDROID_BINDER_IPC_SELFTEST"
+    scripts/config --set-str "ANDROID_BINDER_DEVICES" ""
+    if [[ "$CONDITION12" =~ [yY] ]]; then
+      read -rp "Press enter to continue..."
+    fi
+  fi
+
   # NR_CPUS
   if [ "$_basever" != "601" ]; then
     if [ -n "$_NR_CPUS_value" ]; then


### PR DESCRIPTION
officially no longer active since months.
basically no longer active since ages.

an alternative is available and in active development (also recommended by anbox), no need to keep this here