### PR TITLE
glitched-cfs-additions: fix for 6.5.2, remove performance-killing printk calls in bcachefs patches

### DIFF
--- a/linux-tkg-patches/6.4/0008-6.4-bcachefs.patch
+++ b/linux-tkg-patches/6.4/0008-6.4-bcachefs.patch
@@ -101965,7 +101965,7 @@ diff --git a/mm/madvise.c b/mm/madvise.c
 index b5ffbaf61..e08639a7c 100644
 --- a/mm/madvise.c
 +++ b/mm/madvise.c
-@@ -1311,6 +1311,64 @@ int madvise_set_anon_name(struct mm_struct *mm, unsigned long start,
+@@ -1311,6 +1311,60 @@ int madvise_set_anon_name(struct mm_struct *mm, unsigned long start,
  				 madvise_vma_anon_name);
  }
  #endif /* CONFIG_ANON_VMA_NAME */
@@ -101979,8 +101979,6 @@ index b5ffbaf61..e08639a7c 100644
 +	case (2):
 +		return (unsigned long)kmalloc(size, GFP_KERNEL | __GFP_ACCOUNT);
 +	default:
-+		printk("test_alloc invoked with args in1=%lu in2=%lu\n",
-+			in1, in2);
 +		return 0;
 +	}
 +}
@@ -101996,8 +101994,6 @@ index b5ffbaf61..e08639a7c 100644
 +		kfree((void*)addr);
 +		break;
 +	default:
-+		printk("test_free invoked with args in1=%lu in2=%lu\n",
-+			in1, in2);
 +		break;
 +	}
 +}

--- a/linux-tkg-patches/6.5/0008-6.5-bcachefs.patch
+++ b/linux-tkg-patches/6.5/0008-6.5-bcachefs.patch
@@ -98435,7 +98435,7 @@ diff --git a/mm/madvise.c b/mm/madvise.c
 index ec30f48f8..fa2f140d0 100644
 --- a/mm/madvise.c
 +++ b/mm/madvise.c
-@@ -1330,6 +1330,64 @@ int madvise_set_anon_name(struct mm_struct *mm, unsigned long start,
+@@ -1330,6 +1330,60 @@ int madvise_set_anon_name(struct mm_struct *mm, unsigned long start,
  				 madvise_vma_anon_name);
  }
  #endif /* CONFIG_ANON_VMA_NAME */
@@ -98449,8 +98449,6 @@ index ec30f48f8..fa2f140d0 100644
 +	case (2):
 +		return (unsigned long)kmalloc(size, GFP_KERNEL | __GFP_ACCOUNT);
 +	default:
-+		printk("test_alloc invoked with args in1=%lu in2=%lu\n",
-+			in1, in2);
 +		return 0;
 +	}
 +}
@@ -98466,8 +98464,6 @@ index ec30f48f8..fa2f140d0 100644
 +		kfree((void*)addr);
 +		break;
 +	default:
-+		printk("test_free invoked with args in1=%lu in2=%lu\n",
-+			in1, in2);
 +		break;
 +	}
 +}


### PR DESCRIPTION
- The `printk` calls in `test_free`/`test_malloc` (called from `madvise`) were accidentally left in by the author and can randomly cause major performance problems even if none of the bcachefs options are enabled. They are triggered when `madvise` is called with `MADV_COLLAPSE`. Thousands of these messages attempt to get printed. `dmesg` seems to never stop printing. I was getting messages in journal:

```
Sep 10 23:27:39 limelight kernel: test_alloc invoked with args in1=824637915136 in2=4194304
Sep 10 23:27:39 limelight kernel: test_alloc invoked with args in1=824637915136 in2=4194304
Sep 10 23:27:39 limelight kernel: test_alloc invoked with args in1=824637915136 in2=4194304
Sep 10 23:27:39 limelight kernel: test_alloc invoked with args in1=824637915136 in2=4194304
Sep 10 23:27:39 limelight kernel: test_alloc invoked with args in1=824637915136 in2=4194304
Sep 10 23:27:39 limelight kernel: test_alloc invoked with args in1=824637915136 in2=4194304
Sep 10 23:27:39 limelight kernel: test_alloc invoked with args in1=824637915136 in2=4194304
Sep 10 23:27:39 limelight kernel: test_alloc invoked with args in1=824637915136 in2=4194304
Sep 10 23:27:39 limelight kernel: test_alloc invoked with args in1=824637915136 in2=4194304
Sep 10 23:27:39 limelight kernel: test_alloc invoked with args in1=824637915136 in2=4194304
Sep 10 23:27:39 limelight kernel: test_free invoked with args in1=824637915136 in2=4194304
Sep 10 23:27:39 limelight kernel: test_free invoked with args in1=824637915136 in2=4194304
Sep 10 23:27:39 limelight kernel: test_free invoked with args in1=824637915136 in2=4194304
Sep 10 23:27:39 limelight kernel: test_free invoked with args in1=824637915136 in2=4194304
Sep 10 23:27:39 limelight kernel: test_free invoked with args in1=824637915136 in2=4194304
Sep 10 23:27:39 limelight kernel: test_free invoked with args in1=824637915136 in2=4194304
Sep 10 23:27:39 limelight kernel: test_free invoked with args in1=824637915136 in2=4194304
Sep 10 23:27:39 limelight kernel: test_free invoked with args in1=824637915136 in2=4194304
Sep 10 23:27:39 limelight kernel: test_free invoked with args in1=824637915136 in2=4194304
Sep 10 23:27:39 limelight kernel: test_free invoked with args in1=824637915136 in2=4194304
Sep 10 23:27:39 limelight kernel: test_alloc invoked with args in1=824637915136 in2=4194304
Sep 10 23:27:39 limelight kernel: test_alloc invoked with args in1=824637915136 in2=4194304
Sep 10 23:27:39 limelight kernel: test_alloc invoked with args in1=824637915136 in2=4194304
Sep 10 23:27:39 limelight kernel: test_alloc invoked with args in1=824637915136 in2=4194304
Sep 10 23:27:39 limelight kernel: test_alloc invoked with args in1=824637915136 in2=4194304
Sep 10 23:27:39 limelight kernel: test_alloc invoked with args in1=824637915136 in2=4194304
Sep 10 23:27:39 limelight systemd-journald[707]: Missed 8175 kernel messages
Sep 10 23:27:39 limelight kernel: test_free invoked with args in1=824637915136 in2=4194304
Sep 10 23:27:39 limelight systemd-journald[707]: Missed 181 kernel messages
```