### PR TITLE
Update 0013-fedora-rpm.patch

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -244,10 +244,10 @@ if [ "$1" = "install" ]; then
       _extra_ver_str="_${_kernel_flavor}"
     fi
 
-    _fedora_work_dir="$_kernel_work_folder_abs/linux-tkg-rpmbuild"
+    _fedora_work_dir="$_kernel_work_folder_abs/rpmbuild"
 
     msg2 "Add patched files to the diff.patch"
-    (cd ${_kernel_work_folder_abs} && git add -- . ':!linux-tkg-rpmbuild')
+    (cd ${_kernel_work_folder_abs} && git add -- . ':!rpmbuild')
 
     msg2 "Building kernel RPM packages"
     RPMOPTS="--define '_topdir ${_fedora_work_dir}'" make ${llvm_opt} -j ${_thread_num} rpm-pkg EXTRAVERSION="${_extra_ver_str}"

--- a/linux-tkg-patches/6.6/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/6.6/0013-fedora-rpm.patch
@@ -1,40 +1,47 @@
 diff --git a/scripts/package/kernel.spec b/scripts/package/kernel.spec
-index 8049f0e2c..de170760d 100755
+index 3eee0143e0c5..ece7078c0741 100644
 --- a/scripts/package/kernel.spec
 +++ b/scripts/package/kernel.spec
-@@ -18,2 +18,3 @@ $S	Source2: diff.patch
- Provides: kernel-$KERNELRELEASE
-+Provides: kernel-uname-r = %{version}
- BuildRequires: bc binutils bison dwarves
-@@ -28,4 +29,4 @@ $S	BuildRequires: gcc make openssl openssl-devel perl python3 rsync
+@@ -27,8 +27,8 @@ The Linux Kernel, the operating system core itself
+ %package headers
+ Summary: Header files for the Linux kernel for use by glibc
  Group: Development/System
 -Obsoletes: kernel-headers
  Provides: kernel-headers = %{version}
 +Provides: installonlypkg(kernel) = %{version}
  %description headers
-@@ -41,2 +42,5 @@ $S$M	Summary: Development package for building kernel modules to match the $__KE
- $S$M	Group: System Environment/Kernel
-+$S$M	Provides: kernel-devel = %{version}
-+$S$M	Provides: kernel-devel-uname-r = %{version}
-+$S$M	Provides: installonlypkg(kernel) = %{version}
- $S$M	AutoReqProv: no
-@@ -46,2 +50,18 @@ $S$M	against the $__KERNELRELEASE kernel package.
- $S$M
-+$S	# Opt out of a lot of Fedora hardening flags etc...
-+$S	# See https://src.fedoraproject.org/rpms/redhat-rpm-config//blob/rawhide/f/buildflags.md
-+$S	%undefine _package_note_file
-+$S	%undefine _auto_set_build_flags
-+$S	%undefine _include_frame_pointers
-+$S	%define _build_id_flags -Wl,--build-id=none
-+$S	%undefine _annotated_build
-+$S	%undefine _fortify_level
-+$S	%undefine _hardened_build
-+$S	%global _lto_cflags %{nil}
-+$S	%global _configure_gnuconfig_hack 0
-+$S	%global _configure_libtool_hardening_hack 0
-+$S	# Nearly had to go to the deep web to find documentation on this one... Gosh
-+$S	# See https://github.com/rpm-software-management/rpm/blob/master/macros.in#L471
-+$S	%define _build_id_links none
-+$S
- $S	%prep
-
+ Kernel-headers includes the C header files that specify the interface
+ between the Linux kernel and userspace libraries and programs.  The
+@@ -40,12 +40,31 @@ glibc package.
+ %package devel
+ Summary: Development package for building kernel modules to match the %{version} kernel
+ Group: System Environment/Kernel
++Provides: kernel-devel = %{version}
++Provides: kernel-devel-uname-r = %{version}
++Provides: installonlypkg(kernel) = %{version}
+ AutoReqProv: no
+ %description -n kernel-devel
+ This package provides kernel headers and makefiles sufficient to build modules
+ against the %{version} kernel package.
+ %endif
+ 
++# Opt out of a lot of Fedora hardening flags etc...
++# See https://src.fedoraproject.org/rpms/redhat-rpm-config//blob/rawhide/f/buildflags.md
++%undefine _package_note_file
++%undefine _auto_set_build_flags
++%undefine _include_frame_pointers
++%define _build_id_flags -Wl,--build-id=none
++%undefine _annotated_build
++%undefine _fortify_level
++%undefine _hardened_build
++%global _lto_cflags %{nil}
++%global _configure_gnuconfig_hack 0
++%global _configure_libtool_hardening_hack 0
++# Nearly had to go to the deep web to find documentation on this one... Gosh
++# See https://github.com/rpm-software-management/rpm/blob/master/macros.in#L471
++%define _build_id_links none
++
+ %prep
+ %setup -q -n linux
+ cp %{SOURCE1} .config
+ 

--- a/linux-tkg-patches/6.6/0013-suse-additions.patch
+++ b/linux-tkg-patches/6.6/0013-suse-additions.patch
@@ -280,40 +280,33 @@ index ac3f2ee6d..e96ffc9a7 100644
  %if %{with_devel}
  %package devel
  Summary: Development package for building kernel modules to match the %{version} kernel
-@@ -67,8 +80,8 @@ cp $(%{make} %{makeflags} -s image_name) %{buildroot}/boot/vmlinuz-%{KERNELRELEA
+@@ -67,7 +80,7 @@ cp $(%{make} %{makeflags} -s image_name) %{buildroot}/boot/vmlinuz-%{KERNELRELEA
  %{make} %{makeflags} INSTALL_HDR_PATH=%{buildroot}/usr headers_install
  cp System.map %{buildroot}/boot/System.map-%{KERNELRELEASE}
  cp .config %{buildroot}/boot/config-%{KERNELRELEASE}
 -ln -fns /usr/src/kernels/%{KERNELRELEASE} %{buildroot}/lib/modules/%{KERNELRELEASE}/build
--ln -fns /usr/src/kernels/%{KERNELRELEASE} %{buildroot}/lib/modules/%{KERNELRELEASE}/source
 +ln -fns /usr/src/kernels/%{KERNELRELEASE} %{buildroot}/usr/lib/modules/%{KERNELRELEASE}/build
-+ln -fns /usr/src/kernels/%{KERNELRELEASE} %{buildroot}/usr/lib/modules/%{KERNELRELEASE}/source
  %if %{with_devel}
  %{make} %{makeflags} run-command KBUILD_RUN_COMMAND='${srctree}/scripts/package/install-extmod-build %{buildroot}/usr/src/kernels/%{KERNELRELEASE}'
  %endif
-@@ -99,9 +112,9 @@ fi
+@@ -99,8 +112,8 @@ fi
 
  %files
  %defattr (-, root, root)
 -/lib/modules/%{KERNELRELEASE}
 -%exclude /lib/modules/%{KERNELRELEASE}/build
--%exclude /lib/modules/%{KERNELRELEASE}/source
 +/usr/lib/modules/%{KERNELRELEASE}
 +%exclude /usr/lib/modules/%{KERNELRELEASE}/build
-+%exclude /usr/lib/modules/%{KERNELRELEASE}/source
  /boot/*
 
  %files headers
-@@ -112,6 +125,10 @@ fi
+@@ -112,5 +125,8 @@ fi
  %files devel
  %defattr (-, root, root)
  /usr/src/kernels/%{KERNELRELEASE}
 -/lib/modules/%{KERNELRELEASE}/build
--/lib/modules/%{KERNELRELEASE}/source
 +/usr/lib/modules/%{KERNELRELEASE}/build
-+/usr/lib/modules/%{KERNELRELEASE}/source
  %endif
 +
 +%files syms
 +%defattr (-, root, root)
-+/usr/src/kernels/$KERNELRELEASE/doc


### PR DESCRIPTION
The patch was using the syntax of the mkspec file instead of that of the kernel.spec, leading to the build failing.