### PR TITLE
customization.cfg: modprobeddb_path: add note about chroot

### DIFF
--- a/customization.cfg
+++ b/customization.cfg
@@ -63,7 +63,8 @@ _kernel_on_diet="false"
 _modprobeddb="false"
 
 # modprobed-db database file location
-_modprobeddb_db_path=~/.config/modprobed.db
+# if building on a chroot, set this to modprobed.db and manually copy the modprobed.db file from ~/.config/modprobed.db to linux-tkg root
+_modprobeddb_db_path="~/.config/modprobed.db"
 
 # Set to "1" to call make menuconfig, "2" to call make nconfig, "3" to call make xconfig, before building the kernel. Set to false to disable and skip the prompt.
 _menunconfig=""


### PR DESCRIPTION
i build in chroot, but something seems wrong with this
you set a path, then prepare script prepend $_where to the path, and that should give you an invalid path?
also afaik when executed it will not expand `~`, so the example path should be a wrong example

am i missing something?