### PR TITLE
In case of Fedora: modify kernel configuration to add SELinux. Fix #383

### DIFF
--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -1781,6 +1781,16 @@ CONFIG_DEBUG_INFO_BTF_MODULES=y\r
   msg2 "Setting config"
   make ${_config_updating} ${llvm_opt} |& tee -a "$_where"/logs/prepare.log.txt
 
+  # Modify the kernel config file to fit Fedora SELinux configuration
+  if [ "$_distro" = "Fedora" ] ; then
+    msg2 "SELinux activation for Fedora"
+    _enable "AUDIT"
+    _enable "SECURITY_SELINUX"
+    _enable "DEFAULT_SECURITY_SELINUX"
+    _disable "DEFAULT_SECURITY_DAC"
+    scripts/config --set-str "LSM" "lockdown,yama,integrity,selinux,bpf,landlock"
+  fi
+
   # menuconfig / nconfig
   if [ -z "$_menunconfig" ]; then
     plain ""


### PR DESCRIPTION
Add Fedora kernel configuration for SELinux. This prevent relabel of most files when booting a kernel without this feature.