### PR TITLE
Use --ignore-whitespace flag when patching the work tree

### DIFF
--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -581,7 +581,7 @@ user_patcher() {
 	        msg2 "Reverting your own ${_userpatch_target} patch ${_f}"
 	        msg2 ""
 	        msg2 "######################################################"
-	        patch -Np1 -R < "${_f}"
+	        patch -Np1 -l -R < "${_f}"
 	        echo "Reverted your own patch ${_f}" >> "$_where"/logs/prepare.log.txt
 	      fi
 	    done
@@ -603,7 +603,7 @@ user_patcher() {
 	        msg2 "Applying your own ${_userpatch_target} patch ${_f}"
 	        msg2 ""
 	        msg2 "######################################################"
-	        patch -Np1 < "${_f}"
+	        patch -Np1 -l < "${_f}"
 	        echo "Applied your own patch ${_f}" >> "$_where"/logs/prepare.log.txt
 	      fi
 	    done
@@ -615,7 +615,7 @@ _tkg_patcher() {
   if [ -e "$tkgpatch" ]; then
     msg2 "$_msg"
     echo -e "### Applying ${tkgpatch##*/}... ###" >> "$_where"/logs/prepare.log.txt
-    patch -Np1 -i "$tkgpatch" >> "$_where"/logs/prepare.log.txt || error "An error was encountered applying patches. It was logged to the prepare.log.txt file."
+    patch -Np1 -l -i "$tkgpatch" >> "$_where"/logs/prepare.log.txt || error "An error was encountered applying patches. It was logged to the prepare.log.txt file."
     echo -e "\n" >> "$_where"/logs/prepare.log.txt
   else
     msg2 "Skipping patch ${tkgpatch##*/}...\n         (unavailable for this kernel version)"


### PR DESCRIPTION
Allows patches to apply successfully even with mismatching whitespace characters, making life less hair-pully for people adding their own patches.