### PR TITLE
Add thinkpad_acpi to the diet modprobed-db config

### DIFF
--- a/linux-tkg-config/6.5/minimal-modprobed.db
+++ b/linux-tkg-config/6.5/minimal-modprobed.db
@@ -569,6 +569,7 @@ tea5767
 tee
 tg3
 thermal
+thinkpad_acpi
 thunderbolt
 tiny_power_button
 tls

--- a/linux-tkg-config/6.6/minimal-modprobed.db
+++ b/linux-tkg-config/6.6/minimal-modprobed.db
@@ -569,6 +569,7 @@ tea5767
 tee
 tg3
 thermal
+thinkpad_acpi
 thunderbolt
 tiny_power_button
 tls


### PR DESCRIPTION
Fixes mkinitcpio failing due to missing drm_privacy_screen_register function.

Fixes #854.