### PR TITLE
Fix winesync patch application for 6.7

### DIFF
--- a/linux-tkg-patches/6.7/0007-v6.7-winesync.patch
+++ b/linux-tkg-patches/6.7/0007-v6.7-winesync.patch
@@ -2176,17 +2176,17 @@ Subject: [PATCH 13/34] selftests: winesync: Add some tests for semaphore
  create mode 100644 tools/testing/selftests/drivers/winesync/winesync.c
 
 diff --git a/tools/testing/selftests/Makefile b/tools/testing/selftests/Makefile
-index c852eb40c4f7..a366016d6254 100644
+index 8247a7c69..553c949dc 100644
 --- a/tools/testing/selftests/Makefile
 +++ b/tools/testing/selftests/Makefile
-@@ -14,6 +14,7 @@ TARGETS += drivers/dma-buf
+@@ -18,6 +18,7 @@ TARGETS += drivers/dma-buf
  TARGETS += drivers/s390x/uvdevice
  TARGETS += drivers/net/bonding
  TARGETS += drivers/net/team
 +TARGETS += drivers/winesync
+ TARGETS += dt
  TARGETS += efivarfs
  TARGETS += exec
- TARGETS += filesystems
 diff --git a/tools/testing/selftests/drivers/winesync/Makefile b/tools/testing/selftests/drivers/winesync/Makefile
 new file mode 100644
 index 000000000000..43b39fdeea10


### PR DESCRIPTION
This PR is a simple patch that fixes patch application for the winesync patch for kernel 6.7. There was an error in applying the patch to `tools/testing/selftests/Makefile`.