### PR TITLE
6.8 & 6.9: update diet db

### DIFF
--- a/linux-tkg-config/6.8/minimal-modprobed.db
+++ b/linux-tkg-config/6.8/minimal-modprobed.db
@@ -120,6 +120,7 @@ dns_resolver
 drm
 drm_buddy
 drm_display_helper
+drm_exec
 drm_kms_helper
 drm_panel_orientation_quirks
 drm_suballoc_helper
@@ -391,6 +392,7 @@ ntfs
 ntfs3
 nvidia_wmi_ec_backlight
 nvme
+nvme_auth
 nvme_common
 nvme_core
 nvmem_rave_sp_eeprom
@@ -413,6 +415,7 @@ poly1305_x86_64
 polyval_clmulni
 polyval_generic
 ppdev
+pps_core
 processor_thermal_device
 processor_thermal_device_pci_legacy
 processor_thermal_mbox
@@ -420,6 +423,7 @@ processor_thermal_rapl
 processor_thermal_rfim
 psmouse
 psnap
+ptp
 qcserial
 qrtr
 r8152
@@ -471,6 +475,8 @@ serio
 serio_raw
 ses
 sg
+sha1_ssse3
+sha256_ssse3
 sha512_ssse3
 snd
 snd_acp3x_pdm_dma

--- a/linux-tkg-config/6.9/minimal-modprobed.db
+++ b/linux-tkg-config/6.9/minimal-modprobed.db
@@ -120,6 +120,7 @@ dns_resolver
 drm
 drm_buddy
 drm_display_helper
+drm_exec
 drm_kms_helper
 drm_panel_orientation_quirks
 drm_suballoc_helper
@@ -391,6 +392,7 @@ ntfs
 ntfs3
 nvidia_wmi_ec_backlight
 nvme
+nvme_auth
 nvme_common
 nvme_core
 nvmem_rave_sp_eeprom
@@ -413,6 +415,7 @@ poly1305_x86_64
 polyval_clmulni
 polyval_generic
 ppdev
+pps_core
 processor_thermal_device
 processor_thermal_device_pci_legacy
 processor_thermal_mbox
@@ -420,6 +423,7 @@ processor_thermal_rapl
 processor_thermal_rfim
 psmouse
 psnap
+ptp
 qcserial
 qrtr
 r8152
@@ -471,6 +475,8 @@ serio
 serio_raw
 ses
 sg
+sha1_ssse3
+sha256_ssse3
 sha512_ssse3
 snd
 snd_acp3x_pdm_dma


### PR DESCRIPTION
I just compiled a full 6.8 kernel to get bluetooth working (using my own `modprobed-db` db) and just added what was missing our current `minimal-config` files in 6.8 and 6.9