### PR TITLE
Add min_base_slice_ns for BORE scheduler

### DIFF
--- a/customization.cfg
+++ b/customization.cfg
@@ -240,6 +240,10 @@ _smt_nice=""
 # Arch users can find scx schedulers on the AUR (https://aur.archlinux.org/packages/scx-scheds & https://aur.archlinux.org/packages/scx-scheds-git. For -git scx schedulers the latest rc kernel is reccomended) thanks to @sirlucjan (for persistence, set scheduler in "/etc/default/scx" and enable the `scx` service).
 _eevdf_sched_ext_support="true"
 
+# BORE only - The default lower bound limit of the base slice. Setting this value too high can cause the system to boot with an unnecessarily large base slice, resulting in high scheduling latency and poor system responsiveness.
+# Default is 2000000
+_bore_min_base_slice_ns="1000000"
+
 # Trust the CPU manufacturer to initialize Linux's CRNG (RANDOM_TRUST_CPU) - Kernel default is "false"
 _random_trust_cpu="true"
 

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -1201,6 +1201,7 @@ _tkg_srcprep() {
     _disable "SCHED_PDS"
   elif [[ "${_cpusched}" =~ "bore" ]]; then
     _enable "SCHED_BORE"
+    scripts/config --set-val "MIN_BASE_SLICE_NS" "$_bore_min_base_slice_ns"
   fi
 
   if [[ "${_cpusched}" =~ ^(muqss|pds|bmq|upds)$ ]]; then


### PR DESCRIPTION
CachyOS sets this to 100000, default is 200000
Description reads as:
```
+config MIN_BASE_SLICE_NS
+	int "Default value for min_base_slice_ns"
+	default 2000000
+	help
+	 The BORE Scheduler automatically calculates the optimal base
+	 slice for the configured HZ using the following equation:
+	 
+	 base_slice_ns =
+	 	1000000000/HZ * DIV_ROUNDUP(min_base_slice_ns, 1000000000/HZ)
+	 
+	 This option sets the default lower bound limit of the base slice
+	 to prevent the loss of task throughput due to overscheduling.
+	 
+	 Setting this value too high can cause the system to boot with
+	 an unnecessarily large base slice, resulting in high scheduling
+	 latency and poor system responsiveness.
+
```