### PR TITLE
tkg-patches: 6.12: Fix glitched-base

### DIFF
--- a/linux-tkg-patches/6.12/0003-glitched-base.patch
+++ b/linux-tkg-patches/6.12/0003-glitched-base.patch
@@ -391,15 +391,15 @@ index 4eab3d70e880..79669aa39d79 100644
   */
  static struct elevator_type *elevator_get_default(struct request_queue *q)
  {
- 	if (q->tag_set && q->tag_set->flags & BLK_MQ_F_NO_SCHED_BY_DEFAULT)
+ 	if (q->tag_set->flags & BLK_MQ_F_NO_SCHED_BY_DEFAULT)
  		return NULL;
 
  	if (q->nr_hw_queues != 1 &&
  	    !blk_mq_is_shared_tags(q->tag_set->flags))
  		return NULL;
  
--	return elevator_find_get(q, "mq-deadline");
-+	return elevator_find_get(q, "bfq");
+-	return elevator_find_get("mq-deadline");
++	return elevator_find_get("bfq");
  }
  
  /*


### PR DESCRIPTION
6.12 had a recent change in elevator.c and your gliched-base patch failed to apply because of that.