### PR TITLE
Update the Graysky's per-CPU-arch native optimizations patch name

### DIFF
--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -694,10 +694,8 @@ _tkg_srcprep() {
     _patch_name="more-ISA-levels-and-uarches-for-kernel-5.15-5.16"
   elif ( [ "$_kver" = "601" ] && [ "$_sub" -lt "79" ] ) || ( [ "$_kver" = "606" ] && [ "$_sub" -lt "18" ] ) || ( [ "$_kver" = "607" ] && [ "$_sub" -lt "6" ] ) || [[ "$_kver" =~ ^(517|518|519|600|602|603|604|605)$ ]]; then
     _patch_name="more-ISA-levels-and-uarches-for-kernel-5.17-6.1.78"
-  elif [[ "$_kver" =~ ^(601|606|607)$ ]]; then
-    _patch_name="more-ISA-levels-and-uarches-for-kernel-6.1.79-6.8-rc3"
   else
-    _patch_name="more-ISA-levels-and-uarches-for-kernel-6.8-rc4+"
+    _patch_name="more-ISA-levels-and-uarches-for-kernel-6.1.79+"
   fi
 
   curl "https://raw.githubusercontent.com/graysky2/kernel_compiler_patch/master/${_outdated}${_patch_name}.patch" > "$srcdir"/"${_patch_name}".patch || true


### PR DESCRIPTION
The patch name was changed 2 weeks ago. graysky2/kernel_compiler_patch@44598c402184de0de4c9f0addce5771bf0eae0c4