### PR TITLE
ci fixes

### DIFF
--- a/.github/workflows/arch-builder.yml
+++ b/.github/workflows/arch-builder.yml
@@ -60,7 +60,7 @@ jobs:
       #     echo "${_modprobeddb_db_path}"
 
       - name: Compile Kernel
-        run: su user -c "yes '' | makepkg --noconfirm -s"
+        run: su --preserve-environment user -c "yes '' | makepkg --noconfirm -s"
         # run: |
         #   mkdir -p "$PKGDEST"
         #   echo "test" > "$PKGDEST"/linux-$_cpusched.pkg.tar.zst

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -195,7 +195,7 @@ _set_kver_internal_vars() {
     _default_cpu_sched="eevdf"
   fi
 
-  echo -e "_basekernel='$_basekernel'\n_basever='$_basever'\n_sub='$_sub'\n_kver='$_kver'\n_default_cpu_sched='$_default_cpu_sched'" > "$_where"/BIG_UGLY_FROGMINER
+  echo -e "_basekernel='$_basekernel'\n_basever='$_basever'\n_sub='$_sub'\n_kver='$_kver'\n_default_cpu_sched='$_default_cpu_sched'" >> "$_where"/BIG_UGLY_FROGMINER
 }
 
 _set_kernel_version() {
@@ -256,6 +256,7 @@ _set_kernel_version() {
 
     _kernel_git_tag="$_selected_value"
   fi
+  echo -e "_kernel_git_tag='$_kernel_git_tag'" >> "$_where"/BIG_UGLY_FROGMINER
 }
 
 _set_cpu_scheduler() {
@@ -431,21 +432,18 @@ _set_compiler(){
 
 _define_kernel_abs_paths() {
 
-  if [ -z "$_kernel_work_folder_abs" ]; then
-    _kernel_work_folder_abs="$_where/$_kernel_work_folder/linux-src-git"
-    if [[ "$_kernel_work_folder" == /* ]]; then
-      _kernel_work_folder_abs="$_kernel_work_folder/linux-tkg/linux-src-git"
-    fi
-    echo -e "_kernel_work_folder_abs=\"$_kernel_work_folder_abs\"" >> "$_where"/BIG_UGLY_FROGMINER
+  _kernel_work_folder_abs="$_where/$_kernel_work_folder/linux-src-git"
+  if [[ "$_kernel_work_folder" == /* ]]; then
+    _kernel_work_folder_abs="$_kernel_work_folder/linux-tkg/linux-src-git"
   fi
+  echo -e "_kernel_work_folder_abs=\"$_kernel_work_folder_abs\"" >> "$_where"/BIG_UGLY_FROGMINER
 
-  if [ -z "$_kernel_source_folder_abs" ]; then
-    _kernel_source_folder_abs="$_where/$_kernel_source_folder/linux-kernel.git"
-    if [[ "$_kernel_source_folder" == /* ]]; then
-      _kernel_source_folder_abs="$_kernel_source_folder/linux-tkg/linux-kernel.git"
-    fi
-    echo -e "_kernel_source_folder_abs=\"$_kernel_source_folder_abs\"" >> "$_where"/BIG_UGLY_FROGMINER
+  _kernel_source_folder_abs="$_where/$_kernel_source_folder/linux-kernel.git"
+  if [[ "$_kernel_source_folder" == /* ]]; then
+    _kernel_source_folder_abs="$_kernel_source_folder/linux-tkg/linux-kernel.git"
   fi
+  echo -e "_kernel_source_folder_abs=\"$_kernel_source_folder_abs\"" >> "$_where"/BIG_UGLY_FROGMINER
+
 }
 
 
@@ -624,8 +622,6 @@ _tkg_patcher() {
 }
 
 _tkg_srcprep() {
-
-  _define_kernel_abs_paths
 
   cd "$_kernel_work_folder_abs"
 


### PR DESCRIPTION
It turns out that building with env vars in Arch was somehow always broken, or something changed in `makepkg` recently about env vars, our the PR #1081 subtly changed something, but we've been having issues [like this](https://github.com/Frogging-Family/linux-tkg/actions/runs/14357352030) since.

I took time to look into it, and it was related to the fact that the PKGBUILD gets sourced for each phase, but all the following phases other than the first lose the environment and some important vars get lost. I believe this problem isn't new and that's why the `BIG_UGLY_FROGMINER` file was being used.

I changed the PKGBUILD to dump the env and the config files, in the right order, but only once when the file `BIG_UGLY_FROGMINER` doesn't exist, then the env is always sourced from there and never from elsewhere, the `prepare` script appends things to it litte by little as phases are run. It seems to work nicely.