### PR TITLE
customization: support forwarding user provided compiler flags

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -138,6 +138,9 @@ build() {
       $_ionice -p "$_pid" ||:
     fi
 
+    export KCPPFLAGS
+    export KCFLAGS
+
     time ( make ${_force_all_threads} ${llvm_opt} LOCALVERSION= bzImage modules 2>&1 ) 3>&1 1>&2 2>&3
     return 0
   )

--- a/customization.cfg
+++ b/customization.cfg
@@ -270,6 +270,18 @@ _install_after_building="prompt"
 # [non-Arch only] Use 'script' command for logging
 _logging_use_script="yes"
 
+# [Advanced] Extra flags to pass to the compiler, for C files
+# Important:
+# - If you encounter issues, _ONLY_ report a bug if you have tried a kernel with this variable left blank
+# - Do _NOT_ activate SIMD instructions (i.e do not add e.g. "-mavx") or it will break your system
+KCFLAGS=""
+
+# [Advanced] Extra flags to pass to the compiler, for C++ files
+# Important:
+# - If you encounter issues, _ONLY_ report a bug if you have tried a kernel with this variable left blank
+# - Do _NOT_ activate SIMD instructions (i.e do not add e.g. "-mavx") or it will break your system
+KCPPFLAGS=""
+
 #### LEGACY OPTIONS ####
 
 # Upstreamed version of Fsync from Linux 5.16 for previous kernel versions - https://github.com/andrealmeid/futex_waitv_patches

--- a/install.sh
+++ b/install.sh
@@ -196,6 +196,8 @@ if [ "$1" = "install" ]; then
   msg2 "Add patched files to the diff.patch"
   git add .
 
+  export KCPPFLAGS
+  export KCFLAGS
 
   if [[ "$_distro" =~ ^(Ubuntu|Debian)$ ]]; then
 


### PR DESCRIPTION
A very good gun to shoot yourself in the foot.

We can also hard code it in the `Makefile`, so even `dkms` modules pick them up. I think DKMS doesn't support passing compilers flags, at least I couldn't find how.

Do we want this in ? I think it works in non-Arch already because the environment doesn't get cleared.