### PR TITLE
debian/ubuntu: libncurses5-dev deprecation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -78,7 +78,7 @@ _install_dependencies() {
   fi
   if [ "$_distro" = "Debian" -o "$_distro" = "Ubuntu" ]; then
     msg2 "Installing dependencies"
-    sudo apt install bc bison build-essential ccache cpio fakeroot flex git kmod libdw-dev libelf-dev libncurses5-dev libssl-dev lz4 qtbase5-dev rsync schedtool wget zstd debhelper ${clang_deps} -y
+    sudo apt install bc bison build-essential ccache cpio fakeroot flex git kmod libdw-dev libelf-dev libncurses-dev libssl-dev lz4 qtbase5-dev rsync schedtool wget zstd debhelper ${clang_deps} -y
   elif [ "$_distro" = "Fedora" ]; then
     msg2 "Installing dependencies"
     sudo dnf install openssl-devel-engine hostname perl bison ccache dwarves elfutils-devel elfutils-libelf-devel fedora-packager fedpkg flex gcc-c++ git libXi-devel lz4 make ncurses-devel openssl openssl-devel perl-devel perl-generators pesign python3-devel qt5-qtbase-devel rpm-build rpmdevtools schedtool zstd bc rsync -y ${clang_deps} -y


### PR DESCRIPTION
linux-tkg wasn't compiling in my updated system Debian 13 trixie. So I just edited libncurses5-dev to libncurses-dev then it compiled again. libncurses5-dev package is deprecated now for both Debian 12 and 13. As for Ubuntu, I tested installing libncurses-dev in my Ubuntu 24.04 VM and it worked good, so I guess it'll work in any recent Ubuntu (LTS) or Debian, and fix the issue for Debian 13 (testing for now, but coming to be stable really soon).