### PR TITLE
Remove the no longer existing intelfb

### DIFF
--- a/linux-tkg-patches/6.10/0002-clear-patches.patch
+++ b/linux-tkg-patches/6.10/0002-clear-patches.patch
@@ -317,14 +317,14 @@ ATA init is the long pole in the boot process, and its asynchronous.
 move the graphics init after it so that ata and graphics initialize
 in parallel
 ---
- drivers/Makefile | 15 ++++++++-------
- 1 file changed, 8 insertions(+), 7 deletions(-)
+ drivers/Makefile | 13 +++++++------
+ 1 file changed, 7 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/Makefile b/drivers/Makefile
-index c0cd1b9..af1e2fb 100644
+index fe9ceb0d2288..b58955caf19b 100644
 --- a/drivers/Makefile
 +++ b/drivers/Makefile
-@@ -59,14 +59,8 @@ obj-y				+= char/
+@@ -61,14 +61,8 @@ obj-y				+= char/
  # iommu/ comes before gpu as gpu are using iommu controllers
  obj-y				+= iommu/
  
@@ -339,7 +339,7 @@ index c0cd1b9..af1e2fb 100644
  obj-$(CONFIG_PARPORT)		+= parport/
  obj-y				+= base/ block/ misc/ mfd/ nfc/
  obj-$(CONFIG_LIBNVDIMM)		+= nvdimm/
-@@ -80,6 +73,14 @@ obj-$(CONFIG_IDE)		+= ide/
+@@ -80,6 +74,13 @@ obj-y				+= macintosh/
  obj-y				+= scsi/
  obj-y				+= nvme/
  obj-$(CONFIG_ATA)		+= ata/
@@ -347,9 +347,8 @@ index c0cd1b9..af1e2fb 100644
 +# gpu/ comes after char for AGP vs DRM startup and after iommu
 +obj-y				+= gpu/
 +
-+# i810fb and intelfb depend on char/agp/
++# i810fb depends on char/agp/
 +obj-$(CONFIG_FB_I810)           += video/fbdev/i810/
-+obj-$(CONFIG_FB_INTEL)          += video/fbdev/intelfb/
 +
  obj-$(CONFIG_TARGET_CORE)	+= target/
  obj-$(CONFIG_MTD)		+= mtd/

--- a/linux-tkg-patches/6.11/0002-clear-patches.patch
+++ b/linux-tkg-patches/6.11/0002-clear-patches.patch
@@ -317,14 +317,14 @@ ATA init is the long pole in the boot process, and its asynchronous.
 move the graphics init after it so that ata and graphics initialize
 in parallel
 ---
- drivers/Makefile | 15 ++++++++-------
- 1 file changed, 8 insertions(+), 7 deletions(-)
+ drivers/Makefile | 13 +++++++------
+ 1 file changed, 7 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/Makefile b/drivers/Makefile
-index c0cd1b9..af1e2fb 100644
+index fe9ceb0d2288..b58955caf19b 100644
 --- a/drivers/Makefile
 +++ b/drivers/Makefile
-@@ -59,14 +59,8 @@ obj-y				+= char/
+@@ -61,14 +61,8 @@ obj-y				+= char/
  # iommu/ comes before gpu as gpu are using iommu controllers
  obj-y				+= iommu/
  
@@ -339,7 +339,7 @@ index c0cd1b9..af1e2fb 100644
  obj-$(CONFIG_PARPORT)		+= parport/
  obj-y				+= base/ block/ misc/ mfd/ nfc/
  obj-$(CONFIG_LIBNVDIMM)		+= nvdimm/
-@@ -80,6 +73,14 @@ obj-$(CONFIG_IDE)		+= ide/
+@@ -80,6 +74,13 @@ obj-y				+= macintosh/
  obj-y				+= scsi/
  obj-y				+= nvme/
  obj-$(CONFIG_ATA)		+= ata/
@@ -347,9 +347,8 @@ index c0cd1b9..af1e2fb 100644
 +# gpu/ comes after char for AGP vs DRM startup and after iommu
 +obj-y				+= gpu/
 +
-+# i810fb and intelfb depend on char/agp/
++# i810fb depends on char/agp/
 +obj-$(CONFIG_FB_I810)           += video/fbdev/i810/
-+obj-$(CONFIG_FB_INTEL)          += video/fbdev/intelfb/
 +
  obj-$(CONFIG_TARGET_CORE)	+= target/
  obj-$(CONFIG_MTD)		+= mtd/

--- a/linux-tkg-patches/6.12/0002-clear-patches.patch
+++ b/linux-tkg-patches/6.12/0002-clear-patches.patch
@@ -317,14 +317,14 @@ ATA init is the long pole in the boot process, and its asynchronous.
 move the graphics init after it so that ata and graphics initialize
 in parallel
 ---
- drivers/Makefile | 15 ++++++++-------
- 1 file changed, 8 insertions(+), 7 deletions(-)
+ drivers/Makefile | 13 +++++++------
+ 1 file changed, 7 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/Makefile b/drivers/Makefile
-index c0cd1b9..af1e2fb 100644
+index 45d1c3e630f7..4f5ab2429a7f 100644
 --- a/drivers/Makefile
 +++ b/drivers/Makefile
-@@ -59,14 +59,8 @@ obj-y				+= char/
+@@ -64,14 +64,8 @@ obj-y				+= char/
  # iommu/ comes before gpu as gpu are using iommu controllers
  obj-y				+= iommu/
  
@@ -339,7 +339,7 @@ index c0cd1b9..af1e2fb 100644
  obj-$(CONFIG_PARPORT)		+= parport/
  obj-y				+= base/ block/ misc/ mfd/ nfc/
  obj-$(CONFIG_LIBNVDIMM)		+= nvdimm/
-@@ -80,6 +73,14 @@ obj-$(CONFIG_IDE)		+= ide/
+@@ -83,6 +77,13 @@ obj-y				+= macintosh/
  obj-y				+= scsi/
  obj-y				+= nvme/
  obj-$(CONFIG_ATA)		+= ata/
@@ -347,9 +347,8 @@ index c0cd1b9..af1e2fb 100644
 +# gpu/ comes after char for AGP vs DRM startup and after iommu
 +obj-y				+= gpu/
 +
-+# i810fb and intelfb depend on char/agp/
++# i810fb depends on char/agp/
 +obj-$(CONFIG_FB_I810)           += video/fbdev/i810/
-+obj-$(CONFIG_FB_INTEL)          += video/fbdev/intelfb/
 +
  obj-$(CONFIG_TARGET_CORE)	+= target/
  obj-$(CONFIG_MTD)		+= mtd/

--- a/linux-tkg-patches/6.13/0002-clear-patches.patch
+++ b/linux-tkg-patches/6.13/0002-clear-patches.patch
@@ -317,14 +317,14 @@ ATA init is the long pole in the boot process, and its asynchronous.
 move the graphics init after it so that ata and graphics initialize
 in parallel
 ---
- drivers/Makefile | 15 ++++++++-------
- 1 file changed, 8 insertions(+), 7 deletions(-)
+ drivers/Makefile | 13 +++++++------
+ 1 file changed, 7 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/Makefile b/drivers/Makefile
-index c0cd1b9..af1e2fb 100644
+index 45d1c3e630f7..4f5ab2429a7f 100644
 --- a/drivers/Makefile
 +++ b/drivers/Makefile
-@@ -59,14 +59,8 @@ obj-y				+= char/
+@@ -64,14 +64,8 @@ obj-y				+= char/
  # iommu/ comes before gpu as gpu are using iommu controllers
  obj-y				+= iommu/
  
@@ -339,7 +339,7 @@ index c0cd1b9..af1e2fb 100644
  obj-$(CONFIG_PARPORT)		+= parport/
  obj-y				+= base/ block/ misc/ mfd/ nfc/
  obj-$(CONFIG_LIBNVDIMM)		+= nvdimm/
-@@ -80,6 +73,14 @@ obj-$(CONFIG_IDE)		+= ide/
+@@ -83,6 +77,13 @@ obj-y				+= macintosh/
  obj-y				+= scsi/
  obj-y				+= nvme/
  obj-$(CONFIG_ATA)		+= ata/
@@ -347,9 +347,8 @@ index c0cd1b9..af1e2fb 100644
 +# gpu/ comes after char for AGP vs DRM startup and after iommu
 +obj-y				+= gpu/
 +
-+# i810fb and intelfb depend on char/agp/
++# i810fb depends on char/agp/
 +obj-$(CONFIG_FB_I810)           += video/fbdev/i810/
-+obj-$(CONFIG_FB_INTEL)          += video/fbdev/intelfb/
 +
  obj-$(CONFIG_TARGET_CORE)	+= target/
  obj-$(CONFIG_MTD)		+= mtd/

--- a/linux-tkg-patches/6.14/0002-clear-patches.patch
+++ b/linux-tkg-patches/6.14/0002-clear-patches.patch
@@ -317,14 +317,14 @@ ATA init is the long pole in the boot process, and its asynchronous.
 move the graphics init after it so that ata and graphics initialize
 in parallel
 ---
- drivers/Makefile | 15 ++++++++-------
- 1 file changed, 8 insertions(+), 7 deletions(-)
+ drivers/Makefile | 13 +++++++------
+ 1 file changed, 7 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/Makefile b/drivers/Makefile
-index c0cd1b9..af1e2fb 100644
+index 45d1c3e630f7..4f5ab2429a7f 100644
 --- a/drivers/Makefile
 +++ b/drivers/Makefile
-@@ -59,14 +59,8 @@ obj-y				+= char/
+@@ -64,14 +64,8 @@ obj-y				+= char/
  # iommu/ comes before gpu as gpu are using iommu controllers
  obj-y				+= iommu/
  
@@ -339,7 +339,7 @@ index c0cd1b9..af1e2fb 100644
  obj-$(CONFIG_PARPORT)		+= parport/
  obj-y				+= base/ block/ misc/ mfd/ nfc/
  obj-$(CONFIG_LIBNVDIMM)		+= nvdimm/
-@@ -80,6 +73,14 @@ obj-$(CONFIG_IDE)		+= ide/
+@@ -83,6 +77,13 @@ obj-y				+= macintosh/
  obj-y				+= scsi/
  obj-y				+= nvme/
  obj-$(CONFIG_ATA)		+= ata/
@@ -347,9 +347,8 @@ index c0cd1b9..af1e2fb 100644
 +# gpu/ comes after char for AGP vs DRM startup and after iommu
 +obj-y				+= gpu/
 +
-+# i810fb and intelfb depend on char/agp/
++# i810fb depends on char/agp/
 +obj-$(CONFIG_FB_I810)           += video/fbdev/i810/
-+obj-$(CONFIG_FB_INTEL)          += video/fbdev/intelfb/
 +
  obj-$(CONFIG_TARGET_CORE)	+= target/
  obj-$(CONFIG_MTD)		+= mtd/

--- a/linux-tkg-patches/6.15/0002-clear-patches.patch
+++ b/linux-tkg-patches/6.15/0002-clear-patches.patch
@@ -317,14 +317,14 @@ ATA init is the long pole in the boot process, and its asynchronous.
 move the graphics init after it so that ata and graphics initialize
 in parallel
 ---
- drivers/Makefile | 15 ++++++++-------
- 1 file changed, 8 insertions(+), 7 deletions(-)
+ drivers/Makefile | 13 +++++++------
+ 1 file changed, 7 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/Makefile b/drivers/Makefile
-index c0cd1b9..af1e2fb 100644
+index b5749cf67044..5beba9f57254 100644
 --- a/drivers/Makefile
 +++ b/drivers/Makefile
-@@ -59,14 +59,8 @@ obj-y				+= char/
+@@ -64,14 +64,8 @@ obj-y				+= char/
  # iommu/ comes before gpu as gpu are using iommu controllers
  obj-y				+= iommu/
  
@@ -339,7 +339,7 @@ index c0cd1b9..af1e2fb 100644
  obj-$(CONFIG_PARPORT)		+= parport/
  obj-y				+= base/ block/ misc/ mfd/ nfc/
  obj-$(CONFIG_LIBNVDIMM)		+= nvdimm/
-@@ -80,6 +73,14 @@ obj-$(CONFIG_IDE)		+= ide/
+@@ -83,6 +77,13 @@ obj-y				+= macintosh/
  obj-y				+= scsi/
  obj-y				+= nvme/
  obj-$(CONFIG_ATA)		+= ata/
@@ -347,9 +347,8 @@ index c0cd1b9..af1e2fb 100644
 +# gpu/ comes after char for AGP vs DRM startup and after iommu
 +obj-y				+= gpu/
 +
-+# i810fb and intelfb depend on char/agp/
++# i810fb depends on char/agp/
 +obj-$(CONFIG_FB_I810)           += video/fbdev/i810/
-+obj-$(CONFIG_FB_INTEL)          += video/fbdev/intelfb/
 +
  obj-$(CONFIG_TARGET_CORE)	+= target/
  obj-$(CONFIG_MTD)		+= mtd/

--- a/linux-tkg-patches/6.16/0002-clear-patches.patch
+++ b/linux-tkg-patches/6.16/0002-clear-patches.patch
@@ -319,7 +319,7 @@ in parallel
  1 file changed, 7 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/Makefile b/drivers/Makefile
-index b5749cf67..5beba9f57 100644
+index b5749cf67044..5beba9f57254 100644
 --- a/drivers/Makefile
 +++ b/drivers/Makefile
 @@ -64,14 +64,8 @@ obj-y				+= char/

--- a/linux-tkg-patches/6.16/0002-clear-patches.patch
+++ b/linux-tkg-patches/6.16/0002-clear-patches.patch
@@ -315,14 +315,14 @@ ATA init is the long pole in the boot process, and its asynchronous.
 move the graphics init after it so that ata and graphics initialize
 in parallel
 ---
- drivers/Makefile | 15 ++++++++-------
- 1 file changed, 8 insertions(+), 7 deletions(-)
+ drivers/Makefile | 13 +++++++------
+ 1 file changed, 7 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/Makefile b/drivers/Makefile
-index c0cd1b9..af1e2fb 100644
+index b5749cf67..5beba9f57 100644
 --- a/drivers/Makefile
 +++ b/drivers/Makefile
-@@ -59,14 +59,8 @@ obj-y				+= char/
+@@ -64,14 +64,8 @@ obj-y				+= char/
  # iommu/ comes before gpu as gpu are using iommu controllers
  obj-y				+= iommu/
  
@@ -337,7 +337,7 @@ index c0cd1b9..af1e2fb 100644
  obj-$(CONFIG_PARPORT)		+= parport/
  obj-y				+= base/ block/ misc/ mfd/ nfc/
  obj-$(CONFIG_LIBNVDIMM)		+= nvdimm/
-@@ -80,6 +73,14 @@ obj-$(CONFIG_IDE)		+= ide/
+@@ -83,6 +77,13 @@ obj-y				+= macintosh/
  obj-y				+= scsi/
  obj-y				+= nvme/
  obj-$(CONFIG_ATA)		+= ata/
@@ -345,9 +345,8 @@ index c0cd1b9..af1e2fb 100644
 +# gpu/ comes after char for AGP vs DRM startup and after iommu
 +obj-y				+= gpu/
 +
-+# i810fb and intelfb depend on char/agp/
++# i810fb depends on char/agp/
 +obj-$(CONFIG_FB_I810)           += video/fbdev/i810/
-+obj-$(CONFIG_FB_INTEL)          += video/fbdev/intelfb/
 +
  obj-$(CONFIG_TARGET_CORE)	+= target/
  obj-$(CONFIG_MTD)		+= mtd/

--- a/linux-tkg-patches/6.17/0002-clear-patches.patch
+++ b/linux-tkg-patches/6.17/0002-clear-patches.patch
@@ -315,14 +315,14 @@ ATA init is the long pole in the boot process, and its asynchronous.
 move the graphics init after it so that ata and graphics initialize
 in parallel
 ---
- drivers/Makefile | 15 ++++++++-------
- 1 file changed, 8 insertions(+), 7 deletions(-)
+ drivers/Makefile | 13 +++++++------
+ 1 file changed, 7 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/Makefile b/drivers/Makefile
-index c0cd1b9..af1e2fb 100644
+index b5749cf67044..a935f67eecf2 100644
 --- a/drivers/Makefile
 +++ b/drivers/Makefile
-@@ -59,14 +59,8 @@ obj-y				+= char/
+@@ -64,14 +64,8 @@ obj-y				+= char/
  # iommu/ comes before gpu as gpu are using iommu controllers
  obj-y				+= iommu/
  
@@ -337,17 +337,17 @@ index c0cd1b9..af1e2fb 100644
  obj-$(CONFIG_PARPORT)		+= parport/
  obj-y				+= base/ block/ misc/ mfd/ nfc/
  obj-$(CONFIG_LIBNVDIMM)		+= nvdimm/
-@@ -80,6 +73,14 @@ obj-$(CONFIG_IDE)		+= ide/
+@@ -82,7 +76,14 @@ obj-y				+= cxl/
+ obj-y				+= macintosh/
  obj-y				+= scsi/
  obj-y				+= nvme/
- obj-$(CONFIG_ATA)		+= ata/
 +
+ obj-$(CONFIG_ATA)		+= ata/
 +# gpu/ comes after char for AGP vs DRM startup and after iommu
 +obj-y				+= gpu/
 +
-+# i810fb and intelfb depend on char/agp/
++# i810fb depends on char/agp/
 +obj-$(CONFIG_FB_I810)           += video/fbdev/i810/
-+obj-$(CONFIG_FB_INTEL)          += video/fbdev/intelfb/
 +
  obj-$(CONFIG_TARGET_CORE)	+= target/
  obj-$(CONFIG_MTD)		+= mtd/

--- a/linux-tkg-patches/6.8/0002-clear-patches.patch
+++ b/linux-tkg-patches/6.8/0002-clear-patches.patch
@@ -317,14 +317,14 @@ ATA init is the long pole in the boot process, and its asynchronous.
 move the graphics init after it so that ata and graphics initialize
 in parallel
 ---
- drivers/Makefile | 15 ++++++++-------
- 1 file changed, 8 insertions(+), 7 deletions(-)
+ drivers/Makefile | 13 +++++++------
+ 1 file changed, 7 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/Makefile b/drivers/Makefile
-index c0cd1b9..af1e2fb 100644
+index 37fd6ce3bd7f..8904ad642019 100644
 --- a/drivers/Makefile
 +++ b/drivers/Makefile
-@@ -59,14 +59,8 @@ obj-y				+= char/
+@@ -66,14 +66,8 @@ obj-y				+= char/
  # iommu/ comes before gpu as gpu are using iommu controllers
  obj-y				+= iommu/
  
@@ -339,7 +339,7 @@ index c0cd1b9..af1e2fb 100644
  obj-$(CONFIG_PARPORT)		+= parport/
  obj-y				+= base/ block/ misc/ mfd/ nfc/
  obj-$(CONFIG_LIBNVDIMM)		+= nvdimm/
-@@ -80,6 +73,14 @@ obj-$(CONFIG_IDE)		+= ide/
+@@ -85,6 +79,13 @@ obj-y				+= macintosh/
  obj-y				+= scsi/
  obj-y				+= nvme/
  obj-$(CONFIG_ATA)		+= ata/
@@ -347,9 +347,8 @@ index c0cd1b9..af1e2fb 100644
 +# gpu/ comes after char for AGP vs DRM startup and after iommu
 +obj-y				+= gpu/
 +
-+# i810fb and intelfb depend on char/agp/
++# i810fb depends on char/agp/
 +obj-$(CONFIG_FB_I810)           += video/fbdev/i810/
-+obj-$(CONFIG_FB_INTEL)          += video/fbdev/intelfb/
 +
  obj-$(CONFIG_TARGET_CORE)	+= target/
  obj-$(CONFIG_MTD)		+= mtd/

--- a/linux-tkg-patches/6.9/0002-clear-patches.patch
+++ b/linux-tkg-patches/6.9/0002-clear-patches.patch
@@ -317,14 +317,14 @@ ATA init is the long pole in the boot process, and its asynchronous.
 move the graphics init after it so that ata and graphics initialize
 in parallel
 ---
- drivers/Makefile | 15 ++++++++-------
- 1 file changed, 8 insertions(+), 7 deletions(-)
+ drivers/Makefile | 13 +++++++------
+ 1 file changed, 7 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/Makefile b/drivers/Makefile
-index c0cd1b9..af1e2fb 100644
+index 3bf5cab4b451..3c3ba6266417 100644
 --- a/drivers/Makefile
 +++ b/drivers/Makefile
-@@ -59,14 +59,8 @@ obj-y				+= char/
+@@ -66,14 +66,8 @@ obj-y				+= char/
  # iommu/ comes before gpu as gpu are using iommu controllers
  obj-y				+= iommu/
  
@@ -339,7 +339,7 @@ index c0cd1b9..af1e2fb 100644
  obj-$(CONFIG_PARPORT)		+= parport/
  obj-y				+= base/ block/ misc/ mfd/ nfc/
  obj-$(CONFIG_LIBNVDIMM)		+= nvdimm/
-@@ -80,6 +73,14 @@ obj-$(CONFIG_IDE)		+= ide/
+@@ -85,6 +79,13 @@ obj-y				+= macintosh/
  obj-y				+= scsi/
  obj-y				+= nvme/
  obj-$(CONFIG_ATA)		+= ata/
@@ -347,9 +347,8 @@ index c0cd1b9..af1e2fb 100644
 +# gpu/ comes after char for AGP vs DRM startup and after iommu
 +obj-y				+= gpu/
 +
-+# i810fb and intelfb depend on char/agp/
++# i810fb depends on char/agp/
 +obj-$(CONFIG_FB_I810)           += video/fbdev/i810/
-+obj-$(CONFIG_FB_INTEL)          += video/fbdev/intelfb/
 +
  obj-$(CONFIG_TARGET_CORE)	+= target/
  obj-$(CONFIG_MTD)		+= mtd/


### PR DESCRIPTION
It was removed since gregkh/linux@689237ab37c59b9909bc9371d7fece3081683fba and broke my kernel building. I don't know why it successful in release page.