### PR TITLE
Change header level for Linux-tkg section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## linux-tkg
+# Linux-tkg
 
 This repository provides scripts to automatically download, patch and compile the Linux Kernel from [the official Linux git repository](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git), with a selection of patches aiming for better desktop/gaming experience. The provided patches can be enabled/disabled by editing the `customization.cfg` file and/or by following the interactive install script. You can use an external config file (default is `$HOME/.config/frogminer/linux-tkg.cfg`, tweakable with the `_EXT_CONFIG_PATH` variable in `customization.cfg`). You can also use your own patches (more information in `customization.cfg` file).
 


### PR DESCRIPTION
Updated the header from '## linux-tkg' to '# Linux-tkg' for improved formatting.

Hey, great, dear master. The awesome Linux TKG package should be one size bigger ;) A side effect is that my little TKG installer wrapper script looks better in the preview info and also matches the other packages.