### PR TITLE
Fix llvm-libunwind USE flag path in customization.cfg

### DIFF
--- a/customization.cfg
+++ b/customization.cfg
@@ -122,7 +122,7 @@ _compiler=""
 
 # [Generic and Gentoo specific] Replace `libunwind` with `llvm-libunwind`.
 # ! This is currently experimental.
-# ! It can only work with the `llvm-libunwind` `USE` flag in `sys-devel/clang-common` for Gentoo.
+# ! It can only work with the `llvm-libunwind` `USE` flag in `llvm-core/clang-common` for Gentoo.
 # Set to "true" to enable.
 _libunwind_replace=""
 


### PR DESCRIPTION
Correct the package path for the llvm-libunwind USE flag - Package in Gentoo is now llvm-core instead of sys-devel