### PR TITLE
customization: make _ftracedisable a nuclear option

### DIFF
--- a/customization.cfg
+++ b/customization.cfg
@@ -166,7 +166,10 @@ _sched_yield_type=""
 # Set to "1" for 2ms, "2" for 4ms, "3" for 6ms, "4" for 8ms, or "default" to keep the chosen scheduler defaults.
 _rr_interval=""
 
-# Set to "true" to disable FUNCTION_TRACER/GRAPH_TRACER, lowering overhead but limiting debugging and analyzing of kernel functions - Kernel default is "false"
+# Set to "true" to disable FTRACE, lowering overhead but limiting debugging and analyzing of kernel functions - Kernel default is "false"
+# Notes:
+# - May break many things, as it disables many child config options (FUNCTION_TRACER, GRAPH_TRACER, FBROBE, STACK TRACER...)
+# - Prevents sched-ext LAVD from properly working, see https://github.com/sched-ext/scx/blob/main/kernel.config#L19
 _ftracedisable="false"
 
 # Set to "true" to disable NUMA, lowering overhead, but breaking CUDA/NvEnc on Nvidia equipped systems - Kernel default is "false"

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -1403,15 +1403,9 @@ _tkg_srcprep() {
     _enable "CPU_FREQ_DEFAULT_GOV_ONDEMAND" "CPU_FREQ_GOV_ONDEMAND"
   fi
 
-  # ftrace
-  if [ -z "$_ftracedisable" ]; then
-    plain ""
-    plain "Disable FUNCTION_TRACER/GRAPH_TRACER? Lowers overhead but limits debugging"
-    plain "and analyzing of kernel functions."
-    read -rp "`echo $'    > N/y : '`" CONDITION2;
-  fi
-  if [[ "$CONDITION2" =~ [yY] ]] || [ "$_ftracedisable" = "true" ]; then
-    _disable "FUNCTION_TRACER" "FUNCTION_GRAPH_TRACER"
+  # ftrace disable
+  if [[ "$_ftracedisable" = "true" ]]; then
+    _disable FTRACE
   fi
 
   # disable numa


### PR DESCRIPTION
Entirely disables FTRACE and all its children, I am assuming those of us who disable FUNCTION_TRACER & GRAPH_TRACER actually don't\ need FTRACE altogether.

For the sched-ext issue #1156:
- it seems that FTRACE is needed by at least LAVD
  - issue open here https://github.com/sched-ext/scx/issues/2952
- Got fixed upstream for LAVD to still work with FTRACE disabled but through a less optimal path

What do you think about that @Tk-Glitch ?

Closes: #1157
Closes: #1156