### PR TITLE
Update to enable clang cross compile

### DIFF
--- a/customization.cfg
+++ b/customization.cfg
@@ -120,6 +120,10 @@ _cpusched=""
 # For advanced users.
 _compiler=""
 
+# [Advanced] LLVM target architecture (e.g. "x86_64-linux-gnu").
+# Leave empty to use default.
+_llvm_target_arch=""
+
 # [Generic and Gentoo specific] Replace `libunwind` with `llvm-libunwind`.
 # ! This is currently experimental.
 # ! It can only work with the `llvm-libunwind` `USE` flag in `llvm-core/clang-common` for Gentoo.

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -1060,7 +1060,7 @@ _tkg_srcprep() {
     fi
     if [[ "$_compiler" == "llvm" ]]; then
       # "native" doesn't show up in clang's list, but it's supported
-      if ! ( clang -mcpu=help 2>&1 | grep "$1" &> /dev/null ) ; then
+      if ! ( $( [[ -n "$_llvm_target_arch" ]] && echo "clang --target=$_llvm_target_arch" || echo "clang" ) -mcpu=help 2>&1 | grep "$1" &> /dev/null ) ; then
         return 1
       fi
     fi


### PR DESCRIPTION
clang-cross-compile

In customation added _llvm_target_arch=""

Configure prepare to read _llvm_target_arch

blank --> no change/default

"x86_64-linux-gnu" --> enables cross compiling for x86_64-linux-gnu

