### PR TITLE
rework patch 0013-optimize_harder_O3.patch

### DIFF
--- a/linux-tkg-patches/6.18/0013-optimize_harder_O3.patch
+++ b/linux-tkg-patches/6.18/0013-optimize_harder_O3.patch
@@ -1,47 +1,58 @@
+From 3a2e3b5d9571b86f8856004db14dc60853b09f0f Mon Sep 17 00:00:00 2001
+From: Frogging-Family
+From: Tk-Glitch <ti3nou@gmail.com>
+From: Adel KARA SLIMANE <adel.ks@zegrapher.com>
+From: damachine <damachin3@proton.me>
+Date: Fri, 20 Mar 2026 19:46:07 +0100
+Subject: [PATCH] linux-tkg: tk-glitch 0013-optimize_harder_O3.patch for 6.18
+
+Signed-off-by: patch-family-tool <patches@frogging-family.invalid>
+---
+ Makefile     |  8 ++++++++
+ init/Kconfig | 26 ++++++++++++++++++++++++++
+ 2 files changed, 34 insertions(+)
+
 diff --git a/Makefile b/Makefile
+index 67c2f5dbb..9ceb369a5 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -442,7 +442,7 @@ endif
- HOSTPKG_CONFIG	= pkg-config
-
- KBUILD_USERHOSTCFLAGS := -Wall -Wmissing-prototypes -Wstrict-prototypes \
--			 -O2 -fomit-frame-pointer -std=gnu11
-+			 -O3 -fomit-frame-pointer -std=gnu11
- KBUILD_USERCFLAGS  := $(KBUILD_USERHOSTCFLAGS) $(USERCFLAGS)
- KBUILD_USERLDFLAGS := $(USERLDFLAGS)
-
-@@ -474,7 +474,7 @@ endif
- 
- KBUILD_HOSTCFLAGS   := $(KBUILD_USERHOSTCFLAGS) $(HOST_LFS_CFLAGS) \
- 		       $(HOSTCFLAGS) -I $(srctree)/scripts/include
--KBUILD_HOSTCXXFLAGS := -Wall -O2 $(HOST_LFS_CFLAGS) $(HOSTCXXFLAGS) \
-+KBUILD_HOSTCXXFLAGS := -Wall -O3 $(HOST_LFS_CFLAGS) $(HOSTCXXFLAGS) \
- 		       -I $(srctree)/scripts/include
- KBUILD_HOSTRUSTFLAGS := $(rust_common_flags) -O -Cstrip=debuginfo \
- 			-Zallow-features= $(HOSTRUSTFLAGS)
-@@ -757,7 +757,7 @@ KBUILD_CFLAGS       += $(call cc-disable-warning, format-overflow)
- KBUILD_CFLAGS  += $(call cc-disable-warning, address-of-packed-member)
-
+@@ -870,11 +870,19 @@ KBUILD_CFLAGS	+= -fno-delete-null-pointer-checks
  ifdef CONFIG_CC_OPTIMIZE_FOR_PERFORMANCE
--KBUILD_CFLAGS += -O2
+ KBUILD_CFLAGS += -O2
+ KBUILD_RUSTFLAGS += -Copt-level=2
++else ifdef CONFIG_CC_OPTIMIZE_FOR_PERFORMANCE_O3
 +KBUILD_CFLAGS += -O3
--KBUILD_RUSTFLAGS += -Copt-level=2
 +KBUILD_RUSTFLAGS += -Copt-level=3
  else ifdef CONFIG_CC_OPTIMIZE_FOR_SIZE
  KBUILD_CFLAGS += -Os
+ KBUILD_RUSTFLAGS += -Copt-level=s
+ endif
+ 
++# Perform swing modulo scheduling immediately before the first scheduling pass.
++# This pass looks at innermost loops and reorders their instructions by
++# overlapping different iterations.
++KBUILD_CFLAGS += $(call cc-option,-fmodulo-sched -fmodulo-sched-allow-regmoves -fivopts)
++
+ # Always set `debug-assertions` and `overflow-checks` because their default
+ # depends on `opt-level` and `debug-assertions`, respectively.
+ KBUILD_RUSTFLAGS += -Cdebug-assertions=$(if $(CONFIG_RUST_DEBUG_ASSERTIONS),y,n)
 diff --git a/init/Kconfig b/init/Kconfig
+index cab3ad28c..3a664a42c 100644
 --- a/init/Kconfig
 +++ b/init/Kconfig
-@@ -1401,10 +1401,10 @@ choice
- 	default CC_OPTIMIZE_FOR_PERFORMANCE
-
- config CC_OPTIMIZE_FOR_PERFORMANCE
--	bool "Optimize for performance (-O2)"
-+	bool "Optimize for performance (-O3)"
- 	help
- 	  This is the default optimization level for the kernel, building
--	  with the "-O2" compiler flag for best performance and most
-+	  with the "-O3" compiler flag for best performance and most
+@@ -1541,6 +1561,12 @@ config CC_OPTIMIZE_FOR_PERFORMANCE
+ 	  with the "-O2" compiler flag for best performance and most
  	  helpful compile-time warnings.
-
+ 
++config CC_OPTIMIZE_FOR_PERFORMANCE_O3
++	bool "Optimize more for performance (-O3)"
++	help
++	  Choosing this option will pass "-O3" to your compiler to optimize
++	  the kernel yet more for performance.
++
  config CC_OPTIMIZE_FOR_SIZE
+ 	bool "Optimize for size (-Os)"
+ 	help
+-- 
+2.53.0
+

--- a/linux-tkg-patches/6.19/0013-optimize_harder_O3.patch
+++ b/linux-tkg-patches/6.19/0013-optimize_harder_O3.patch
@@ -1,47 +1,58 @@
+From 71da87313c2d8959d261d6275c0f23ccfe82938a Mon Sep 17 00:00:00 2001
+From: Frogging-Family
+From: Tk-Glitch <ti3nou@gmail.com>
+From: Adel KARA SLIMANE <adel.ks@zegrapher.com>
+From: damachine <damachin3@proton.me>
+Date: Fri, 20 Mar 2026 19:47:30 +0100
+Subject: [PATCH] linux-tkg: tk-glitch 0013-optimize_harder_O3.patch for 6.19
+
+Signed-off-by: patch-family-tool <patches@frogging-family.invalid>
+---
+ Makefile     |  8 ++++++++
+ init/Kconfig | 26 ++++++++++++++++++++++++++
+ 2 files changed, 34 insertions(+)
+
 diff --git a/Makefile b/Makefile
+index 96640a963..2b373183f 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -442,7 +442,7 @@ endif
- HOSTPKG_CONFIG	= pkg-config
-
- KBUILD_USERHOSTCFLAGS := -Wall -Wmissing-prototypes -Wstrict-prototypes \
--			 -O2 -fomit-frame-pointer -std=gnu11
-+			 -O3 -fomit-frame-pointer -std=gnu11
- KBUILD_USERCFLAGS  := $(KBUILD_USERHOSTCFLAGS) $(USERCFLAGS)
- KBUILD_USERLDFLAGS := $(USERLDFLAGS)
-
-@@ -474,7 +474,7 @@ endif
- 
- KBUILD_HOSTCFLAGS   := $(KBUILD_USERHOSTCFLAGS) $(HOST_LFS_CFLAGS) \
- 		       $(HOSTCFLAGS) -I $(srctree)/scripts/include
--KBUILD_HOSTCXXFLAGS := -Wall -O2 $(HOST_LFS_CFLAGS) $(HOSTCXXFLAGS) \
-+KBUILD_HOSTCXXFLAGS := -Wall -O3 $(HOST_LFS_CFLAGS) $(HOSTCXXFLAGS) \
- 		       -I $(srctree)/scripts/include
- KBUILD_HOSTRUSTFLAGS := $(rust_common_flags) -O -Cstrip=debuginfo \
- 			-Zallow-features= $(HOSTRUSTFLAGS)
-@@ -757,7 +757,7 @@ KBUILD_CFLAGS       += $(call cc-disable-warning, format-overflow)
- KBUILD_CFLAGS  += $(call cc-disable-warning, address-of-packed-member)
-
+@@ -889,11 +889,19 @@ KBUILD_CFLAGS	+= -fno-delete-null-pointer-checks
  ifdef CONFIG_CC_OPTIMIZE_FOR_PERFORMANCE
--KBUILD_CFLAGS += -O2
+ KBUILD_CFLAGS += -O2
+ KBUILD_RUSTFLAGS += -Copt-level=2
++else ifdef CONFIG_CC_OPTIMIZE_FOR_PERFORMANCE_O3
 +KBUILD_CFLAGS += -O3
--KBUILD_RUSTFLAGS += -Copt-level=2
 +KBUILD_RUSTFLAGS += -Copt-level=3
  else ifdef CONFIG_CC_OPTIMIZE_FOR_SIZE
  KBUILD_CFLAGS += -Os
+ KBUILD_RUSTFLAGS += -Copt-level=s
+ endif
+ 
++# Perform swing modulo scheduling immediately before the first scheduling pass.
++# This pass looks at innermost loops and reorders their instructions by
++# overlapping different iterations.
++KBUILD_CFLAGS += $(call cc-option,-fmodulo-sched -fmodulo-sched-allow-regmoves -fivopts)
++
+ # Always set `debug-assertions` and `overflow-checks` because their default
+ # depends on `opt-level` and `debug-assertions`, respectively.
+ KBUILD_RUSTFLAGS += -Cdebug-assertions=$(if $(CONFIG_RUST_DEBUG_ASSERTIONS),y,n)
 diff --git a/init/Kconfig b/init/Kconfig
+index fa79feb8f..6c8ba1a1a 100644
 --- a/init/Kconfig
 +++ b/init/Kconfig
-@@ -1401,10 +1401,10 @@ choice
- 	default CC_OPTIMIZE_FOR_PERFORMANCE
-
- config CC_OPTIMIZE_FOR_PERFORMANCE
--	bool "Optimize for performance (-O2)"
-+	bool "Optimize for performance (-O3)"
- 	help
- 	  This is the default optimization level for the kernel, building
--	  with the "-O2" compiler flag for best performance and most
-+	  with the "-O3" compiler flag for best performance and most
+@@ -1566,6 +1586,12 @@ config CC_OPTIMIZE_FOR_PERFORMANCE
+ 	  with the "-O2" compiler flag for best performance and most
  	  helpful compile-time warnings.
-
+ 
++config CC_OPTIMIZE_FOR_PERFORMANCE_O3
++	bool "Optimize more for performance (-O3)"
++	help
++	  Choosing this option will pass "-O3" to your compiler to optimize
++	  the kernel yet more for performance.
++
  config CC_OPTIMIZE_FOR_SIZE
+ 	bool "Optimize for size (-Os)"
+ 	help
+-- 
+2.53.0
+

--- a/linux-tkg-patches/7.0/0013-optimize_harder_O3.patch
+++ b/linux-tkg-patches/7.0/0013-optimize_harder_O3.patch
@@ -1,47 +1,58 @@
+From 72ffe355a000543a19f41bf149a4094c6b4af724 Mon Sep 17 00:00:00 2001
+From: Frogging-Family
+From: Tk-Glitch <ti3nou@gmail.com>
+From: Adel KARA SLIMANE <adel.ks@zegrapher.com>
+From: damachine <damachin3@proton.me>
+Date: Fri, 20 Mar 2026 19:48:52 +0100
+Subject: [PATCH] linux-tkg: tk-glitch 0013-optimize_harder_O3.patch for 7.0
+
+Signed-off-by: patch-family-tool <patches@frogging-family.invalid>
+---
+ Makefile     |  8 ++++++++
+ init/Kconfig | 26 ++++++++++++++++++++++++++
+ 2 files changed, 34 insertions(+)
+
 diff --git a/Makefile b/Makefile
+index c9b7bee10..880a637c6 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -442,7 +442,7 @@ endif
- HOSTPKG_CONFIG	= pkg-config
-
- KBUILD_USERHOSTCFLAGS := -Wall -Wmissing-prototypes -Wstrict-prototypes \
--			 -O2 -fomit-frame-pointer -std=gnu11
-+			 -O3 -fomit-frame-pointer -std=gnu11
- KBUILD_USERCFLAGS  := $(KBUILD_USERHOSTCFLAGS) $(USERCFLAGS)
- KBUILD_USERLDFLAGS := $(USERLDFLAGS)
-
-@@ -474,7 +474,7 @@ endif
- 
- KBUILD_HOSTCFLAGS   := $(KBUILD_USERHOSTCFLAGS) $(HOST_LFS_CFLAGS) \
- 		       $(HOSTCFLAGS) -I $(srctree)/scripts/include
--KBUILD_HOSTCXXFLAGS := -Wall -O2 $(HOST_LFS_CFLAGS) $(HOSTCXXFLAGS) \
-+KBUILD_HOSTCXXFLAGS := -Wall -O3 $(HOST_LFS_CFLAGS) $(HOSTCXXFLAGS) \
- 		       -I $(srctree)/scripts/include
- KBUILD_HOSTRUSTFLAGS := $(rust_common_flags) -O -Cstrip=debuginfo \
- 			-Zallow-features= $(HOSTRUSTFLAGS)
-@@ -757,7 +757,7 @@ KBUILD_CFLAGS       += $(call cc-disable-warning, format-overflow)
- KBUILD_CFLAGS  += $(call cc-disable-warning, address-of-packed-member)
-
+@@ -893,11 +893,19 @@ KBUILD_CFLAGS	+= -fno-delete-null-pointer-checks
  ifdef CONFIG_CC_OPTIMIZE_FOR_PERFORMANCE
--KBUILD_CFLAGS += -O2
+ KBUILD_CFLAGS += -O2
+ KBUILD_RUSTFLAGS += -Copt-level=2
++else ifdef CONFIG_CC_OPTIMIZE_FOR_PERFORMANCE_O3
 +KBUILD_CFLAGS += -O3
--KBUILD_RUSTFLAGS += -Copt-level=2
 +KBUILD_RUSTFLAGS += -Copt-level=3
  else ifdef CONFIG_CC_OPTIMIZE_FOR_SIZE
  KBUILD_CFLAGS += -Os
+ KBUILD_RUSTFLAGS += -Copt-level=s
+ endif
+ 
++# Perform swing modulo scheduling immediately before the first scheduling pass.
++# This pass looks at innermost loops and reorders their instructions by
++# overlapping different iterations.
++KBUILD_CFLAGS += $(call cc-option,-fmodulo-sched -fmodulo-sched-allow-regmoves -fivopts)
++
+ # Always set `debug-assertions` and `overflow-checks` because their default
+ # depends on `opt-level` and `debug-assertions`, respectively.
+ KBUILD_RUSTFLAGS += -Cdebug-assertions=$(if $(CONFIG_RUST_DEBUG_ASSERTIONS),y,n)
 diff --git a/init/Kconfig b/init/Kconfig
+index 444ce811e..694ddcbf4 100644
 --- a/init/Kconfig
 +++ b/init/Kconfig
-@@ -1401,10 +1401,10 @@ choice
- 	default CC_OPTIMIZE_FOR_PERFORMANCE
-
- config CC_OPTIMIZE_FOR_PERFORMANCE
--	bool "Optimize for performance (-O2)"
-+	bool "Optimize for performance (-O3)"
- 	help
- 	  This is the default optimization level for the kernel, building
--	  with the "-O2" compiler flag for best performance and most
-+	  with the "-O3" compiler flag for best performance and most
+@@ -1582,6 +1602,12 @@ config CC_OPTIMIZE_FOR_PERFORMANCE
+ 	  with the "-O2" compiler flag for best performance and most
  	  helpful compile-time warnings.
-
+ 
++config CC_OPTIMIZE_FOR_PERFORMANCE_O3
++	bool "Optimize more for performance (-O3)"
++	help
++	  Choosing this option will pass "-O3" to your compiler to optimize
++	  the kernel yet more for performance.
++
  config CC_OPTIMIZE_FOR_SIZE
+ 	bool "Optimize for size (-Os)"
+ 	help
+-- 
+2.53.0
+


### PR DESCRIPTION
Hi, it's me again 👋

I cherry-picked and adapted the patches from CachyOS <3, merging both commits into a single patch for versions 6.18, 6.19 and 7.0, tested with patch --dry-run -p1 + live.

https://github.com/CachyOS/linux/commit/b01a1820ca34ece352e6778c8a7f21e8192f63d5
https://github.com/CachyOS/linux/commit/1caa661d25c47ba6115621b2a3f52c39f021c9d8

This adds -fmodulo-sched, -fmodulo-sched-allow-regmoves and -fivopts flags as well as a separate CC_OPTIMIZE_FOR_PERFORMANCE_O3 Kconfig option. The patch retains its original purpose and functionality — no behavioral changes, just a rework to stay in sync.

KISS