### PR TITLE
pkgbuild: add KSMBD to provides array, sync header depends

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -183,9 +183,9 @@ hackbase() {
               'update-grub: Simple wrapper around grub-mkconfig.'
               'scx-scheds: to use sched-ext schedulers')
   if [ -e "${srcdir}/ntsync.rules" ]; then
-    provides=("linux=${pkgver}" "${pkgbase}" VIRTUALBOX-GUEST-MODULES WIREGUARD-MODULE NTSYNC-MODULE ntsync-header)
+    provides=("linux=${pkgver}" "${pkgbase}" KSMBD-MODULE VIRTUALBOX-GUEST-MODULES WIREGUARD-MODULE NTSYNC-MODULE ntsync-header)
   else
-    provides=("linux=${pkgver}" "${pkgbase}" VIRTUALBOX-GUEST-MODULES WIREGUARD-MODULE)
+    provides=("linux=${pkgver}" "${pkgbase}" KSMBD-MODULE VIRTUALBOX-GUEST-MODULES WIREGUARD-MODULE)
   fi
   replaces=(virtualbox-guest-modules-arch wireguard-arch)
 
@@ -248,9 +248,17 @@ hackheaders() {
 
   pkgdesc="Headers and scripts for building modules for the $pkgdesc kernel - https://github.com/Frogging-Family/linux-tkg"
   provides=("linux-headers=${pkgver}" "${pkgbase}-headers=${pkgver}")
-  if [[ $_kver -gt 510 ]]; then  
-    depends=('pahole')
-  fi
+  depends=(
+    binutils
+    glibc
+    libelf
+    libgcc
+    openssl
+    pahole
+    xxhash
+    zlib
+    zstd
+  )
 
   cd "$_kernel_work_folder_abs"
 


### PR DESCRIPTION
Hi! Some parts of the PKGBUILD still seemed a bit stuck in the "old way", so I wanted to freshen things up a bit. I hope these changes feel right!

PKGBUILD: Update provides and depends

- **hackbase()**: Added `ksmbd` to the `provides` array. 
This module has been integrated into the mainline kernel since version 5.15 and should be listed for userspace tools.
- **hackheaders()**: Synced depends with current Arch/CachyOS standards.
Removed the `-gt` version comparison. Is there still a reason to keep this?

Refs:
* [KSMBD Mainline Mergelog (v5.15)](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/fs/ksmbd?h=v5.15)
* [Upstream PKGBUILD Reference](https://gitlab.archlinux.org/archlinux/packaging/packages/linux-zen/-/blob/main/PKGBUILD?ref_type=heads#L119)

<3