### PR TITLE
fix: use portable shebangs for non-FHS compatibility

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Stop the script at any ecountered error
 set -e


### PR DESCRIPTION
Changed `#!/bin/bash` to `#!/usr/bin/env bash` in `install.sh`

`#!/bin/bash` assumes bash lives at `/bin/bash`, which is not true on non-FHS compliant distros like NixOS. `#!/usr/bin/env bash` uses `env` to locate bash from `$PATH`, making the scripts portable across all Linux distros.