### PR TITLE
linux-tkg: drop kernel-6.19 to EOL, refresh pkgbuild, minor adjustment

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -66,7 +66,7 @@ pkgrel=273
 pkgdesc='Linux-tkg'
 arch=('x86_64') # no i686 in here
 url="https://www.kernel.org/"
-license=('GPL2')
+license=('GPL-2.0-only')
 makedepends=(
   bc
   binutils
@@ -174,14 +174,17 @@ hackbase() {
 
   pkgdesc="The $pkgdesc kernel and modules - https://github.com/Frogging-Family/linux-tkg"
   depends=('coreutils' 'kmod' 'initramfs')
-  optdepends=('linux-docs: Kernel hackers manual - HTML documentation that comes with the Linux kernel.'
-              'crda: to set the correct wireless channels of your country.'
-              'linux-firmware: Firmware files for Linux'
-              'modprobed-db: Keeps track of EVERY kernel module that has ever been probed. Useful for make localmodconfig.'
-              'nvidia-tkg: NVIDIA drivers for all installed kernels - non-dkms version.'
-              'nvidia-dkms-tkg: NVIDIA drivers for all installed kernels - dkms version.'
-              'update-grub: Simple wrapper around grub-mkconfig.'
-              'scx-scheds: to use sched-ext schedulers')
+  optdepends=(
+    "$pkgname-headers: headers and scripts for building modules"
+    'linux-firmware: firmware images needed for some devices'
+    'linux-docs: Kernel hackers manual - HTML documentation that comes with the Linux kernel.'
+    'nvidia-tkg: NVIDIA drivers for all installed kernels - non-dkms version.'
+    'nvidia-dkms-tkg: NVIDIA drivers for all installed kernels - dkms version.'
+    'modprobed-db: Keeps track of EVERY kernel module that has ever been probed. Useful for make localmodconfig.'
+    'update-grub: Simple wrapper around grub-mkconfig.'
+    'scx-scheds: to use sched-ext schedulers'
+    'wireless-regdb: to set the correct wireless channels of your country'
+  )
   if [ -e "${srcdir}/ntsync.rules" ]; then
     provides=("linux=${pkgver}" "${pkgbase}" KSMBD-MODULE VIRTUALBOX-GUEST-MODULES WIREGUARD-MODULE NTSYNC-MODULE ntsync-header)
   else

--- a/install.sh
+++ b/install.sh
@@ -158,7 +158,7 @@ if [ "$1" = "install" ]; then
   fi
 
   # ccache
-  if [ "$_noccache" != "true" ]; then
+  if [ "$_noccache" != "true" ] && command -v ccache >/dev/null 2>&1; then
     export PATH="/usr/lib64/ccache/:/usr/lib/ccache/bin/:$PATH"
 
     export CCACHE_SLOPPINESS="file_macro,locale,time_macros"

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # List of kernels that are maintained upstream
-_current_kernels=("7.1" "7.0" "6.19" "6.18" "6.12" "6.6" "6.1" "5.15" "5.10")
+_current_kernels=("7.1" "7.0" "6.18" "6.12" "6.6" "6.1" "5.15" "5.10")
 
 # List of kernels that are no longer maintained either upstream or locally
-_eol_kernels=("6.17" "6.16" "6.15" "6.14" "6.13" "6.11" "6.10" "6.9" "6.8" "6.7" "6.5" "6.4" "6.3" "6.2" "6.0" "5.19" "5.18" "5.17" "5.16" "5.14" "5.13" "5.12" "5.11" "5.9" "5.8" "5.7" "5.4")
+_eol_kernels=("6.19" "6.17" "6.16" "6.15" "6.14" "6.13" "6.11" "6.10" "6.9" "6.8" "6.7" "6.5" "6.4" "6.3" "6.2" "6.0" "5.19" "5.18" "5.17" "5.16" "5.14" "5.13" "5.12" "5.11" "5.9" "5.8" "5.7" "5.4")
 
 _deprecated_config_vars=(
   "_use_tmpfs"
@@ -2025,13 +2025,6 @@ exit_cleanup() {
   fi
   echo "#################" >> "$_where"/logs/system-info.txt
   gcc -v >> "$_where"/logs/system-info.txt 2>&1
-
-  # Arch: move shell-output.log to logs folder
-  if [[ "$_distro" = "Arch" && -f "$_where"/shell-output.log ]]; then
-    mv -f "$_where"/shell-output.log "$_where"/logs/shell-output.log.txt
-    sed -i 's/\x1b\[[0-9;]*m//g' "$_where"/logs/shell-output.log.txt
-    sed -i 's/\x1b(B//g' "$_where"/logs/shell-output.log.txt
-  fi
 }
 
 trap exit_cleanup EXIT


### PR DESCRIPTION
Hey, I don't think I need to say much about this.

We seem to run this twice for Arch :thinking:
https://github.com/Frogging-Family/linux-tkg/blob/00dfead1cd6eb12e7a8df05b041160fef810b890/linux-tkg-config/prepare#L2029

This should suffice here:
https://github.com/Frogging-Family/linux-tkg/blob/00dfead1cd6eb12e7a8df05b041160fef810b890/linux-tkg-config/prepare#L1925

I know this is a usermod parameter and rather minor, but I noticed it after adding the linux-tkg logging to the nvidia-all logic. If I haven't completely missed something (spaces) xD, this should be okay.

Other small changes:

- PKGBUILD hackbase(): Remove crda from optdepends (it's no longer in the Arch repo) and added $pkgname-headers.
- install.sh: Only enable ccache when the binary is available (matching PKGBUILD logic).
- prepare: Move 6.19 to EOL list

Take care. Peace <3