### PR TITLE
add '_vanilla' toggle: do not add any* extra patch

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -24,10 +24,12 @@ fi
 
 source "$_where"/BIG_UGLY_FROGMINER
 
+_vanilla_tag=""
+_vanilla_mode && _vanilla_tag="vanilla-"
 if [ -n "$_custom_pkgbase" ]; then
   pkgbase="${_custom_pkgbase}"
 else
-  pkgbase=linux"${_basever}"-tkg-"${_cpusched}"${_compiler_name}
+  pkgbase="linux${_basever}-tkg-${_vanilla_tag}${_cpusched}${_compiler_name}"
 fi
 pkgname=("${pkgbase}" "${pkgbase}-headers")
 pkgver="${_basekernel}"."${_sub}"

--- a/customization.cfg
+++ b/customization.cfg
@@ -245,6 +245,10 @@ _gentoo_init="systemd"
 
 #### SPESHUL OPTION ####
 
+# Do not apply any extra patch on top the upstream kernel sources
+# This means, among other things, that only the default upstream scheduler is available
+_vanilla=""
+
 # Do not query nor fetch kernel sources from git remotes on the internet.
 # Only use the kernel versions that have already been fetched in the $_kernel_source_folder
 _offline=""

--- a/install.sh
+++ b/install.sh
@@ -155,11 +155,13 @@ if [ "$1" = "install" ]; then
     msg2 'Enabled ccache'
   fi
 
+  _vanilla_tag=""
+  _vanilla_mode && _vanilla_tag="vanilla-"
   if [ -z "$_kernel_localversion" ]; then
     if [ "$_preempt_rt" = "1" ]; then
-      _kernel_flavor="tkg-${_cpusched}-rt${_compiler_name}"
+      _kernel_flavor="tkg-${_vanilla_tag}${_cpusched}-rt${_compiler_name}"
     else
-      _kernel_flavor="tkg-${_cpusched}${_compiler_name}"
+      _kernel_flavor="tkg-${_vanilla_tag}${_cpusched}${_compiler_name}"
     fi
   else
     if [[ "$_kernel_localversion" != *tkg* ]]; then

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -166,6 +166,10 @@ _module() {
   done
 }
 
+_vanilla_mode() {
+  [[ "$_vanilla" =~ ^(Y|y|Yes|yes|true|1)$ ]];
+}
+
 _prompt_from_array() {
   # Prompts from array, selects default index on empty user input
   # Set the _default_index variable to enable default index selection
@@ -389,8 +393,9 @@ _set_cpu_scheduler() {
     _avail_cpu_scheds+=("muqss")
   fi
 
-  if [ "${_preempt_rt}" = "1" ]; then
-    warning "! Since you have enabled _preempt_rt, incompatible cpu schedulers will not be available !"
+  if [[ "${_preempt_rt}" == "1" ]] || _vanilla_mode; then
+    [[ "${_preempt_rt}" == "1" ]] && warning "! Since you have enabled _preempt_rt, incompatible cpu schedulers will not be available !"
+    _vanilla_mode && warning "_vanilla toggle active, only default scheduler available"
     _avail_cpu_scheds=("$_default_cpu_sched")
   fi
 
@@ -673,7 +678,7 @@ _tkg_initscript() {
 user_patcher() {
     for _f in "$_where"/*."${_userpatch_ext}patch" "$_where"/*."${_userpatch_ext}revert"; do
       if [ -e "${_f}" ]; then
-        warning "Found userpatch file ${f##*/} in the PKGBUILD directory." #"
+        warning "Found userpatch file ${_f##*/} in the PKGBUILD directory." #"
         warning "Userpatches must now be placed in version-specific subdirectories (linux${_basever}-tkg-userpatches for this kernel version)."
         warning "The patch will not be applied."
       fi
@@ -684,6 +689,7 @@ user_patcher() {
 	# To patch the user because all your base are belong to us
 	local _patches=("$_where"/linux"$_basever"-tkg-userpatches/*."${_userpatch_ext}revert")
 	if [ ${#_patches[@]} -ge 2 ] || [ -e "${_patches}" ]; then
+    _vanilla_mode && warning "Vanilla mode is enabled, you may not want to apply some of these user revert patches."
 	  if [ "$_user_patches_no_confirm" != "true" ]; then
 	    msg2 "Found ${#_patches[@]} 'to revert' userpatches for ${_userpatch_target}:"
 	    printf '%s\n' "${_patches[@]}"
@@ -706,6 +712,7 @@ user_patcher() {
 
 	_patches=("$_where"/linux"$_basever"-tkg-userpatches/*."${_userpatch_ext}patch")
 	if [ ${#_patches[@]} -ge 2 ] || [ -e "${_patches}" ]; then
+    _vanilla_mode && warning "Vanilla mode is enabled, you may not want to apply some of these user patches."
 	  if [ "$_user_patches_no_confirm" != "true" ]; then
 	    msg2 "Found ${#_patches[@]} userpatches for ${_userpatch_target}:"
 	    printf '%s\n' "${_patches[@]}"
@@ -728,6 +735,10 @@ user_patcher() {
 }
 
 _tkg_patcher() {
+  if _vanilla_mode && [[ "$1" != "--vanilla-friendly" ]]; then
+    warning "_vanilla toggle active: not applying ${tkgpatch##*/}"
+    return 0
+  fi
   if [ -e "$tkgpatch" ] && [[ $(wc -l <"$tkgpatch") -ge 7 ]]; then
     msg2 "$_msg"
     echo -e "### Applying ${tkgpatch##*/}... ###" >> "$_where"/logs/prepare.log.txt
@@ -748,16 +759,15 @@ _tkg_srcprep() {
   fi
 
   if [ "${_distro}" = "Arch" ]; then
+    local _vanilla_tag=""
+    _vanilla_mode && _vanilla_tag="vanilla-"
     if [ -n "$_custom_pkgbase" ]; then
-      if [[ "$_custom_pkgbase" != *tkg* ]]; then
-        _localversion_tag="-tkg-"
-      else
-        _localversion_tag="-"
-      fi
-      echo "-${pkgrel}${_localversion_tag}${_custom_pkgbase}" > localversion.10-pkgrel
+      local _tkg_watermark=""
+      [[ "$_custom_pkgbase" != *tkg* ]] && _tkg_watermark="tkg-"
+      echo "-${pkgrel}-${_tkg_watermark}${_vanilla_tag}${_custom_pkgbase}" > localversion.10-pkgrel
       echo -e "Version tail set to \"-${pkgrel}${_localversion_tag}${_custom_pkgbase}\"\n" > "$_where"/logs/prepare.log.txt
     else
-      echo "-$pkgrel-tkg-${_cpusched}${_compiler_name}" > localversion.10-pkgrel
+      echo "-$pkgrel-tkg-${_vanilla_tag}${_cpusched}${_compiler_name}" > localversion.10-pkgrel
       echo -e "Version tail set to \"-$pkgrel-tkg-${_cpusched}${_compiler_name}\"\n" > "$_where"/logs/prepare.log.txt
     fi
     echo "" > localversion.20-pkgname
@@ -823,24 +833,24 @@ _tkg_srcprep() {
   fi
 
   tkgpatch="$srcdir/0013-fedora-rpm.patch"
-  _msg="RPM: fixing spec generator" && _tkg_patcher
+  _msg="RPM: fixing spec generator" && _tkg_patcher --vanilla-friendly
 
   if [[ "$_STRIP" == "true" ]]; then
     tkgpatch="$srcdir/0013-fedora-strip-modules.patch"
-    _msg="RPM: strip modules" && _tkg_patcher
+    _msg="RPM: strip modules" && _tkg_patcher --vanilla-friendly
   fi
 
   if [ "$_distro" = "Suse" ]; then
     tkgpatch="$srcdir/0013-suse-additions.patch"
-    _msg="Import Suse-specific patches" && _tkg_patcher
+    _msg="Import Suse-specific patches" && _tkg_patcher --vanilla-friendly
   fi
 
   if [ "$_distro" = "Gentoo" ]; then
     # https://dev.gentoo.org/~mpagano/genpatches/trunk/
     tkgpatch="$srcdir/0013-gentoo-kconfig.patch"
-    _msg="Import Gentoo-kconfig patches" && _tkg_patcher
+    _msg="Import Gentoo-kconfig patches" && _tkg_patcher --vanilla-friendly
     tkgpatch="$srcdir/0013-gentoo-print-loaded-firmware.patch"
-    _msg="Print firmware names on load" && _tkg_patcher
+    _msg="Print firmware names on load" && _tkg_patcher --vanilla-friendly
   fi
 
   if [ -z $_misc_adds ]; then


### PR DESCRIPTION
Hey @Tk-Glitch  and all,

I was about to report something upstream about `x2apic`, turns out it's not a linux bug, but I think this toggle can be useful sometimes.

The approach I suggest is to simply affect `_tkgpatcher` to make it refuse patching unless it is told that it's a "vanilla patch". All the CONFIG changes that rely on patches will be written then cleaned up later by `make defconfig` so it shouldn't matter ?

Feedback welcome.