### PR TITLE
prepare: harden exit cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,6 @@ kernel_updates
 gnupg/
 *sha256sum*
 current_env
+BIG_UGLY_FROGMINER
 linux-kernel.git/
 linux-src-git/

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -96,7 +96,7 @@ prepare() {
 
   rm -rf $pkgdir # Nuke the entire pkg folder so it'll get regenerated clean on next build
 
-  ln -s "${_kernel_work_folder_abs}" "${srcdir}"
+  ln -sf "${_kernel_work_folder_abs}" "${srcdir}"
 
   _tkg_srcprep
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -26,29 +26,16 @@ plain '             `.-:///////:-.`'
 
 _where="$PWD" # track basedir as different Arch based distros are moving srcdir around
 
+source "$_where"/linux-tkg-config/prepare
+
 # Create BIG_UGLY_FROGMINER only on first run and save in it all settings
 if [ ! -e "$_where"/BIG_UGLY_FROGMINER ]; then
 
-  cp "$_where"/customization.cfg "$_where"/BIG_UGLY_FROGMINER
-  echo >> "$_where"/BIG_UGLY_FROGMINER
-
-  # extract and define value of _EXT_CONFIG_PATH from customization file
-  if [[ -z "$_EXT_CONFIG_PATH" ]]; then
-    eval `grep _EXT_CONFIG_PATH "$_where"/customization.cfg`
-  fi
-
-  if [ -f "$_EXT_CONFIG_PATH" ]; then
-    msg2 "External configuration file $_EXT_CONFIG_PATH will be used and will override customization.cfg values."
-    cat "$_EXT_CONFIG_PATH" >> "$_where"/BIG_UGLY_FROGMINER
-    echo >> "$_where"/BIG_UGLY_FROGMINER
-  fi
-
-  declare -p -x >> "$_where"/BIG_UGLY_FROGMINER
+  aggregate_user_config
 
   echo -e "_ispkgbuild=\"true\"\n_distro=\"Arch\"\n_where=\"$PWD\"" >> "$_where"/BIG_UGLY_FROGMINER
 
   source "$_where"/BIG_UGLY_FROGMINER
-  source "$_where"/linux-tkg-config/prepare
 
   _tkg_initscript
 fi

--- a/install.sh
+++ b/install.sh
@@ -37,22 +37,6 @@ plain() {
 
 ################### Config sourcing
 
-# We are either not using script or not within the script sub-command yet
-# we don't export the environment in the script sub-command so sourcing current_env will
-# get us the actual environment
-if [[ -z "$SCRIPT" ]]; then
-  declare -p -x > current_env
-fi
-
-source customization.cfg
-
-if [ -e "$_EXT_CONFIG_PATH" ]; then
-  msg2 "External configuration file $_EXT_CONFIG_PATH will be used and will override customization.cfg values."
-  source "$_EXT_CONFIG_PATH"
-fi
-
-. current_env
-
 if which script &> /dev/null && [[ "$_logging_use_script" =~ ^(Y|y|Yes|yes)$ && -z "$SCRIPT" ]]; then
   # using script is enabled, but we are not within the script sub-command
   export SCRIPT=1
@@ -61,7 +45,8 @@ if which script &> /dev/null && [[ "$_logging_use_script" =~ ^(Y|y|Yes|yes)$ && 
   exit
 fi
 
-source linux-tkg-config/prepare
+source linux-tkg-config/prepare && aggregate_user_config
+source "$_where/BIG_UGLY_FROGMINER"
 
 ####################################################################
 

--- a/install.sh
+++ b/install.sh
@@ -5,8 +5,10 @@ set -e
 
 ###################### Definition of helper variables and functions
 
-_where=`pwd`
+_where=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 srcdir="$_where"
+
+cd "$_where"
 
 # Command used for superuser privileges (`sudo`, `doas`, `su`)
 if [ ! -x "$(command -v sudo)" ]; then

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -1969,6 +1969,7 @@ exit_cleanup() {
   rm -f "$_where"/*.hook
   rm -f "$_where"/cleanup
   rm -f "$_where"/prepare
+  rm -f "$_where"/minimal-modprobed.db
 
   # Remove state tracker
   rm -f "$_where"/BIG_UGLY_FROGMINER

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -535,7 +535,7 @@ _setup_kernel_work_folder() {
   cd "$_where"
 
   if ! [ -d "$_kernel_source_folder_abs" ]; then
-    msg2 "First initialization of the linux source code git folder"
+    msg2 "First initialization of the linux source code git folder"  | tee -a "$_where/logs/git_work.log.txt"
     mkdir -p "$_kernel_source_folder_abs"
     cd "$_kernel_source_folder_abs"
     git -c init.defaultBranch=master init --bare
@@ -544,29 +544,30 @@ _setup_kernel_work_folder() {
   cd "$_kernel_source_folder_abs"
 
   if [[ ! "$_offline" =~ ^(y|Y|yes|true|True)$ ]]; then
-    msg2 "Fetching tag: $_kernel_git_tag from remote $_git_mirror" | tee "$_where/git_work.log.txt"
-    git fetch --depth 1 $_git_mirror tag "$_kernel_git_tag" &>> "$_where/git_work.log.txt"
+    msg2 "Fetching tag: $_kernel_git_tag from remote $_git_mirror" | tee -a "$_where/logs/git_work.log.txt"
+    git fetch --depth 1 $_git_mirror tag "$_kernel_git_tag" &>> "$_where/logs/git_work.log.txt"
   fi
 
-  msg2 "Checking out tag: $_kernel_git_tag" | tee -a "$_where/git_work.log"
-  msg2 "   in the work folder: $_kernel_work_folder_abs" | tee -a "$_where/git_work.log.txt"
+  msg2 "Checking out tag: $_kernel_git_tag" | tee -a "$_where/logs/git_work.log.txt"
+  msg2 "   in the work folder: $_kernel_work_folder_abs" | tee -a "$_where/logs/git_work.log.txt"
 
   # The space ' ' in grep -w "$_kernel_work_folder_abs " is important
   # to not match an existing folder with a longer name with the same prefix name
   if [ -d "$_kernel_work_folder_abs" ] && \
      ( git worktree list | grep -w "$_kernel_work_folder_abs " &> /dev/null ) && \
      ( cd "$_kernel_work_folder_abs" && git status &> /dev/null ); then
-    # Worktree folder exists and is a valid worktree
+    msg2 "Worktree folder $_kernel_work_folder_abs exists and is a valid worktree folder" | tee -a "$_where/logs/git_work.log.txt"
     cd "$_kernel_work_folder_abs"
-    git reset --hard &>> "$_where/git_work.log.txt"
-    git clean -ffdx &>> "$_where/git_work.log.txt"
-    git am --abort &>> "$_where/git_work.log.txt" || true
-    git rebase --abort &>> "$_where/git_work.log.txt" || true
-    git checkout "$_kernel_git_tag" &>> "$_where/git_work.log.txt"
+    git reset --hard &>> "$_where/logs/git_work.log.txt"
+    git clean -ffdx &>> "$_where/logs/git_work.log.txt"
+    git am --abort &>> "$_where/logs/git_work.log.txt" || true
+    git rebase --abort &>> "$_where/logs/git_work.log.txt" || true
+    git checkout "$_kernel_git_tag" &>> "$_where/logs/git_work.log.txt"
   else
     # In all other cases, just force create the work tree
-    rm -rf "$_kernel_work_folder_abs" &>> "$_where/git_work.log.txt"
-    git worktree add -f "$_kernel_work_folder_abs" "$_kernel_git_tag" &>> "$_where/git_work.log.txt"
+    msg2 "Force creating fresh git worktree folder $_kernel_work_folder_abs" | tee -a "$_where/logs/git_work.log.txt"
+    rm -rf "$_kernel_work_folder_abs" &>> "$_where/logs/git_work.log.txt"
+    git worktree add -f "$_kernel_work_folder_abs" "$_kernel_git_tag" &>> "$_where/logs/git_work.log.txt"
   fi
 
   _set_kver_internal_vars

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -2003,7 +2003,11 @@ exit_cleanup() {
   fi
 
   if [ "${_distro}" = "Arch" ]; then
-    remove_deps || ( true && msg2 "remove_deps not found" )
+    if command -v remove_deps &>/dev/null; then
+      remove_deps
+    else
+      msg2 "remove_deps not found"
+    fi
   fi
 
   msg2 'exit cleanup done\n'

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -573,6 +573,39 @@ _setup_kernel_work_folder() {
 }
 
 
+# Aggregate user configuration into BIG_UGLY_FROGMINER.
+# Duplicated variables are merged: env vars > ext config file > repo's customization.cfg
+# Strips blank lines and comments
+aggregate_user_config() {
+  local _cfg="${_where}/customization.cfg"
+
+  # Resolve _EXT_CONFIG_PATH from customization.cfg if not already in env
+  [[ -z "${_EXT_CONFIG_PATH:-}" ]] && eval "$(grep -m1 '^_EXT_CONFIG_PATH=' "$_cfg")"
+
+  [[ -f "${_EXT_CONFIG_PATH}" ]] && \
+    msg2 "External configuration file ${_EXT_CONFIG_PATH} will be used and will override customization.cfg values."
+
+  # Collect valid cfg keys to filter env overrides against
+  local -A _keys=()
+  local _k _v
+  while IFS='= ' read -r _k _; do
+    [[ -n "$_k" && "$_k" != '#'* ]] && _keys["$_k"]=1
+  done < "$_cfg"
+
+  # Emit env > ext > cfg, then strip blanks/comments and dedup by key (first wins)
+  {
+    while IFS='=' read -r _k _v; do
+      [[ -v "_keys[$_k]" ]] && printf '%s=%s\n' "$_k" "$_v"
+    done < <(printenv)
+
+    [[ -f "${_EXT_CONFIG_PATH}" ]] && cat "${_EXT_CONFIG_PATH}"
+    cat "$_cfg"
+  } | grep -v -E '^[[:space:]]*(#|$)' \
+    | awk -F= '!seen[$1]++' \
+    > "${_where}/BIG_UGLY_FROGMINER"
+}
+
+
 _tkg_initscript() {
 
   if ! whereis git > /dev/null 2>&1; then

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -1981,60 +1981,6 @@ exit_cleanup() {
     rm -f "$_where"/linux"$_basever"-tkg-userpatches/"$_p"
   done
 
-  if [ "$_NUKR" = "true" ] && [ "$_where" != "$srcdir" ]; then
-    rm -rf "$_where"/src/*
-    # Double tap
-    rm -rf "$srcdir"/linux-*
-    rm -rf "$srcdir"/*.xz
-    rm -rf "$srcdir"/*.patch
-    rm -rf "$srcdir"/*-profile.cfg
-    rm -rf "$srcdir"/*.rules
-    rm -f "$srcdir"/config.x86_64
-    rm -f "$srcdir"/customization.cfg
-
-  elif [ "$_distro" == "Arch" ]; then
-    rm -rf "$srcdir"/linux-${_basekernel}/Documentation/filesystems/aufs/*
-    rm -f "$srcdir"/linux-${_basekernel}/Documentation/ABI/testing/*-aufs
-    rm -rf "$srcdir"/linux-${_basekernel}/fs/aufs/*
-    rm -f "$srcdir"/linux-${_basekernel}/include/uapi/linux/aufs*
-
-    rm -f "$srcdir"/linux-${_basekernel}/mm/prfile.c
-
-    rm -f "$srcdir"/linux-${_basekernel}/block/bfq*
-
-    rm -rf "$srcdir"/linux-${_basekernel}/drivers/scsi/vhba/*
-
-    rm -rf "$srcdir"/linux-${_basekernel}/fs/exfat/*
-    rm -f "$srcdir"/linux-${_basekernel}/include/trace/events/fs.h
-
-    rm -f "$srcdir"/linux-${_basekernel}/Documentation/scheduler/sched-PDS-mq.txt
-    rm -f "$srcdir"/linux-${_basekernel}/include/linux/skip_list.h
-    rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/pds.c
-    rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/pds_sched.h
-
-    rm -f "$srcdir"/linux-${_basekernel}/Documentation/scheduler/sched-BMQ.txt
-    rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/${_sched}.c
-    rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/sched/alt_debug.c
-    rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/alt_sched.h
-
-    rm -f "$srcdir"/linux-${_basekernel}/Documentation/scheduler/sched-BFS.txt
-    rm -f "$srcdir"/linux-${_basekernel}/Documentation/scheduler/sched-MuQSS.txt
-    rm -rf "$srcdir"/linux-${_basekernel}/arch/blackfin/*
-    rm -f "$srcdir"/linux-${_basekernel}/arch/powerpc/configs/c2k_defconfig
-    rm -f "$srcdir"/linux-${_basekernel}/arch/score/configs/spct6600_defconfig
-    rm -f "$srcdir"/linux-${_basekernel}/arch/tile/configs/tilegx_defconfig
-    rm -f "$srcdir"/linux-${_basekernel}/arch/tile/configs/tilepro_defconfig
-    rm -f "$srcdir"/linux-${_basekernel}/drivers/staging/lustre/lnet/lnet/lib-eq.c
-    rm -f "$srcdir"/linux-${_basekernel}/kernel/sched/MuQSS*
-    rm -f "$srcdir"/linux-${_basekernel}/kernel/skip_list.c
-
-    rm -f "$srcdir"/linux-${_basekernel}/Documentation/vm/uksm.txt
-    rm -f "$srcdir"/linux-${_basekernel}/include/linux/sradix-tree.h
-    rm -f "$srcdir"/linux-${_basekernel}/include/linux/uksm.h
-    rm -f "$srcdir"/linux-${_basekernel}/lib/sradix-tree.c
-    rm -f "$srcdir"/linux-${_basekernel}/mm/uksm.c
-  fi
-
   if [ "${_distro}" = "Arch" ]; then
     if command -v remove_deps &>/dev/null; then
       remove_deps

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -1972,8 +1972,8 @@ exit_cleanup() {
   rm -f "$_where"/prepare
   rm -f "$_where"/minimal-modprobed.db
 
-  # Remove state tracker
-  rm -f "$_where"/BIG_UGLY_FROGMINER
+  # Move BIG_UGLY_FROGMINER into the logs, since it has the actual final customization state
+  [[ -f "$_where"/BIG_UGLY_FROGMINER ]] && mv "$_where"/BIG_UGLY_FROGMINER "$_where"/logs/customization.cfg.txt
 
   # Remove ntsync rules file
   rm -f "$_where"/ntsync.rules
@@ -1995,9 +1995,6 @@ exit_cleanup() {
   if [ -n "$_runtime" ]; then
     msg2 "compilation time : \n$_runtime"
   fi
-
-  # Copy over the customization.cfg file to the logs folder
-  cp -f "$_where"/customization.cfg "$_where"/logs/customization.cfg.txt
 
   [[ -f "$_where"/git_work.log.txt ]] && \
     mv -f "$_where"/git_work.log.txt "$_where"/logs/git_work.log.txt


### PR DESCRIPTION
Hi all <3, I looked into a small issues nothing wild

I suspect remove_deps is mostly a CI/makepkg-context thing. I have not fully validated every path yet, but we can safely avoid noisy command-not-found output when it is unavailable.

fix:
The logs directory now gets created before any cp/mv writes. Without that, files can land in the wrong place depending on execution context.

added:
A snapshot of the external cfg is now saved into logs as well, which should help with debugging and post-mortem analysis.