### PR TITLE
patch(6.18 7.0 7.1): refresh 0013-fedora-rpm.patch

### DIFF
--- a/linux-tkg-patches/6.18/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/6.18/0013-fedora-rpm.patch
@@ -4,8 +4,8 @@ Date: Sat, 7 Feb 2026 18:52:48 +0100
 Subject: [PATCH] package: kernel.spec: various RPM fixes
 
 ---
- scripts/package/kernel.spec | 19 ++++++++++++++++++-
- 1 file changed, 18 insertions(+), 1 deletion(-)
+ scripts/package/kernel.spec | 22 +++++++++++++++++++++-
+ 1 file changed, 21 insertions(+), 1 deletion(-)
 
 diff --git a/scripts/package/kernel.spec b/scripts/package/kernel.spec
 index 0f1c8de1bd95..c569b69274b3 100644
@@ -52,6 +52,16 @@ index 0f1c8de1bd95..c569b69274b3 100644
  %description headers
  Kernel-headers includes the C header files that specify the interface
  between the Linux kernel and userspace libraries and programs.  The
+@@ -40,6 +49,9 @@ glibc package.
+ %package devel
+ Summary: Development package for building kernel modules to match the %{version} kernel
+ Group: System Environment/Kernel
++Provides: kernel-devel = %{version}
++Provides: kernel-devel-uname-r = %{version}
++Provides: installonlypkg(kernel) = %{version}
+ AutoReqProv: no
+ %description -n kernel-devel
+ This package provides kernel headers and makefiles sufficient to build modules
+
 -- 
 2.53.0
-

--- a/linux-tkg-patches/6.18/patchwork/last-successful-check/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/6.18/patchwork/last-successful-check/0013-fedora-rpm.patch
@@ -1,2 +1,2 @@
-_patch_branch_hash=b3557152090791a1f3d08ebe9df4294aa0a51d96cb88370878585700b71d69b0
-_patch_kernel_tag=v6.18.33
+_patch_branch_hash=fbacca773857b070fd0a5bf11e07a50bea9e242736f875fff4aa941d71a53727
+_patch_kernel_tag=v6.18.34

--- a/linux-tkg-patches/7.0/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/7.0/0013-fedora-rpm.patch
@@ -4,8 +4,8 @@ Date: Sat, 7 Feb 2026 18:52:48 +0100
 Subject: [PATCH] package: kernel.spec: various RPM fixes
 
 ---
- scripts/package/kernel.spec | 19 ++++++++++++++++++-
- 1 file changed, 18 insertions(+), 1 deletion(-)
+ scripts/package/kernel.spec | 22 +++++++++++++++++++++-
+ 1 file changed, 21 insertions(+), 1 deletion(-)
 
 diff --git a/scripts/package/kernel.spec b/scripts/package/kernel.spec
 index 0f1c8de1bd95..c569b69274b3 100644
@@ -52,6 +52,17 @@ index 0f1c8de1bd95..c569b69274b3 100644
  %description headers
  Kernel-headers includes the C header files that specify the interface
  between the Linux kernel and userspace libraries and programs.  The
+@@ -40,6 +49,9 @@ glibc package.
+ %package devel
+ Summary: Development package for building kernel modules to match the %{version} kernel
+ Group: System Environment/Kernel
++Provides: kernel-devel = %{version}
++Provides: kernel-devel-uname-r = %{version}
++Provides: installonlypkg(kernel) = %{version}
+ AutoReqProv: no
+ %description -n kernel-devel
+ This package provides kernel headers and makefiles sufficient to build modules
+
 -- 
 2.53.0
 

--- a/linux-tkg-patches/7.0/patchwork/last-successful-check/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/7.0/patchwork/last-successful-check/0013-fedora-rpm.patch
@@ -1,2 +1,2 @@
-_patch_branch_hash=b3557152090791a1f3d08ebe9df4294aa0a51d96cb88370878585700b71d69b0
-_patch_kernel_tag=v7.0.10
+_patch_branch_hash=0618b76d63a7d5ac43bd7eb313a09953f59272d696ec872f3483d8323e1b23eb
+_patch_kernel_tag=v7.0.11

--- a/linux-tkg-patches/7.1/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/7.1/0013-fedora-rpm.patch
@@ -4,8 +4,8 @@ Date: Sat, 7 Feb 2026 18:52:48 +0100
 Subject: [PATCH] package: kernel.spec: various RPM fixes
 
 ---
- scripts/package/kernel.spec | 19 ++++++++++++++++++-
- 1 file changed, 18 insertions(+), 1 deletion(-)
+ scripts/package/kernel.spec | 22 +++++++++++++++++++++-
+ 1 file changed, 21 insertions(+), 1 deletion(-)
 
 diff --git a/scripts/package/kernel.spec b/scripts/package/kernel.spec
 index 0f1c8de1bd95..c569b69274b3 100644
@@ -52,6 +52,17 @@ index 0f1c8de1bd95..c569b69274b3 100644
  %description headers
  Kernel-headers includes the C header files that specify the interface
  between the Linux kernel and userspace libraries and programs.  The
+@@ -40,6 +49,9 @@ glibc package.
+ %package devel
+ Summary: Development package for building kernel modules to match the %{version} kernel
+ Group: System Environment/Kernel
++Provides: kernel-devel = %{version}
++Provides: kernel-devel-uname-r = %{version}
++Provides: installonlypkg(kernel) = %{version}
+ AutoReqProv: no
+ %description -n kernel-devel
+ This package provides kernel headers and makefiles sufficient to build modules
+
 -- 
 2.53.0
 

--- a/linux-tkg-patches/7.1/patchwork/last-successful-check/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/7.1/patchwork/last-successful-check/0013-fedora-rpm.patch
@@ -1,2 +1,2 @@
-_patch_branch_hash=b3557152090791a1f3d08ebe9df4294aa0a51d96cb88370878585700b71d69b0
-_patch_kernel_tag=v7.1-rc5
+_patch_branch_hash=0618b76d63a7d5ac43bd7eb313a09953f59272d696ec872f3483d8323e1b23eb
+_patch_kernel_tag=v7.1-rc6

--- a/linux-tkg-patches/patchwork
+++ b/linux-tkg-patches/patchwork
@@ -278,6 +278,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 
   # needed for things to work in 'prepare'
   _where=$(realpath "$_script_dir"/..)
+  mkdir -p "$_where/logs"
 
   . "$_where"/linux-tkg-config/prepare
 


### PR DESCRIPTION
Add the standard Fedora kernel-devel Provides to the linux-tkg devel RPM.

This makes the package visible as a matching kernel-devel provider for module
build tooling and marks it as an installonly kernel package, allowing linux-tkg
kernel-devel to be installed alongside Fedora kernel-devel instead of causing
DNF transaction conflicts with kernel-devel-matched.

Should solve #1161 

fyi the fedora patches were already solved the same way in 6.1 and 6.6, nothing new really 🐸