### PR TITLE
Patch 7.1 7.2: Huge "summer" refresh

### DIFF
--- a/customization.cfg
+++ b/customization.cfg
@@ -130,6 +130,10 @@ _libunwind_replace=""
 # Set to "0" to disable if desired, otherwise stick to the default behavior.
 _llvm_ias="1"
 
+# Enable Clang Polly loop optimizations. Default is "1" when using LLVM.
+# Requires the LLVMPolly.so plugin to be available to Clang.
+_llvm_polly="1"
+
 # Clang LTO mode, only available with the "llvm" compiler - options are "no", "full" or "thin".
 # ! This is currently experimental and might result in an unbootable kernel - Not recommended !
 # "no: do not enable LTO"

--- a/customization.cfg
+++ b/customization.cfg
@@ -231,7 +231,7 @@ _aggressive_ondemand="true"
 _tcp_cong_alg=""
 
 # You can pass a default set of kernel command line options here - example: "intel_pstate=passive nowatchdog amdgpu.ppfeaturemask=0xfffd7fff mitigations=off"
-_custom_commandline="intel_pstate=passive split_lock_detect=off"
+_custom_commandline="intel_pstate=passive"
 
 # Selection of Clearlinux patches
 _clear_patches="true"

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -1386,6 +1386,17 @@ _tkg_srcprep() {
     fi
   fi
 
+  tkgpatch="$srcdir/0013-clang-polly.patch"
+  if [ -e "$tkgpatch" ]; then
+    if [[ "$_llvm_polly" =~ ^(true|yes|1)$ ]] && [ "$_compiler" = "llvm" ]; then
+      _msg="Patching Clang Polly optimization"
+      _tkg_patcher
+      ! _vanilla_mode && _enable "POLLY_CLANG"
+    elif [[ "$_llvm_polly" =~ ^(true|yes|1)$ ]] && [ "$_compiler" != "llvm" ]; then
+      warning "Clang Polly requires LLVM, skipping."
+    fi
+  fi
+
   # irq threading
   if [ "$_irq_threading" = "true" ]; then
     _enable "FORCE_IRQ_THREADING"

--- a/linux-tkg-patches/7.1/0003-glitched-base.patch
+++ b/linux-tkg-patches/7.1/0003-glitched-base.patch
@@ -1,42 +1,43 @@
-From f7f49141a5dbe9c99d78196b58c44307fb2e6be3 Mon Sep 17 00:00:00 2001
+From bc11a34a1a07178adc9d3df7a6c0889b88e0d5ae Mon Sep 17 00:00:00 2001
 From: Tk-Glitch <ti3nou@gmail.com>
 Date: Wed, 4 Jul 2018 04:30:08 +0200
-Subject: [PATCH 01/17] glitched
+Subject: [PATCH 01/21] glitched
 
 ---
  init/Makefile | 2 +-
- 1 file changed, 1 insertions(+), 1 deletions(-)
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/init/Makefile b/init/Makefile
-index baf3ab8d9d49..854e32e6aec7 100755
+index d6f75d890..9fa3e5890 100644
 --- a/init/Makefile
 +++ b/init/Makefile
-@@ -19,7 +19,7 @@ else
-
+@@ -34,7 +34,7 @@ build-timestamp = $(or $(KBUILD_BUILD_TIMESTAMP), $(build-timestamp-auto))
+ 
  # Maximum length of UTS_VERSION is 64 chars
  filechk_uts_version = \
 -	utsver=$$(echo '$(pound)'"$(build-version)" $(smp-flag-y) $(preempt-flag-y) "$(build-timestamp)" | cut -b -64); \
 +	utsver=$$(echo '$(pound)'"$(build-version)" $(smp-flag-y) $(preempt-flag-y) "TKG" "$(build-timestamp)" | cut -b -64); \
  	echo '$(pound)'define UTS_VERSION \""$${utsver}"\"
-
+ 
  #
 -- 
-2.28.0
+2.55.0
 
 
-From c304f43d14e98d4bf1215fc10bc5012f554bdd8a Mon Sep 17 00:00:00 2001
+From 6c215b31de789f44a5871f1fd77070509cece3bb Mon Sep 17 00:00:00 2001
 From: Alexandre Frade <admfrade@gmail.com>
 Date: Mon, 29 Jan 2018 16:59:22 +0000
-Subject: [PATCH 02/17] dcache: cache_pressure = 50 decreases the rate at which
+Subject: [PATCH 02/21] dcache: cache_pressure = 50 decreases the rate at which
  VFS caches are reclaimed
 
 Signed-off-by: Alexandre Frade <admfrade@gmail.com>
 ---
- fs/dcache.c | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ fs/dcache.c       | 2 +-
+ kernel/sched/rt.c | 4 ++--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/fs/dcache.c b/fs/dcache.c
-index 361ea7ab30ea..0c5cf69b241a 100644
+index 2c61aeea4..a2535f516 100644
 --- a/fs/dcache.c
 +++ b/fs/dcache.c
 @@ -73,7 +73,7 @@
@@ -48,15 +49,11 @@ index 361ea7ab30ea..0c5cf69b241a 100644
  static int sysctl_vfs_cache_pressure_denom __read_mostly = 100;
  
  unsigned long vfs_pressure_ratio(unsigned long val)
--- 
-2.28.0
-
-
 diff --git a/kernel/sched/rt.c b/kernel/sched/rt.c
-index f788cd61df21..2bfbb4213707 100644
+index 4ee8faf01..5368571cd 100644
 --- a/kernel/sched/rt.c
 +++ b/kernel/sched/rt.c
-@@ -15,9 +15,9 @@ __read_mostly int scheduler_running;
+@@ -19,9 +19,9 @@ int sysctl_sched_rt_period = 1000000;
  
  /*
   * part of the period that we allow rt tasks to run in us.
@@ -67,15 +64,15 @@ index f788cd61df21..2bfbb4213707 100644
 +int sysctl_sched_rt_runtime = 980000;
  
  #ifdef CONFIG_SYSCTL
- static int sysctl_sched_rr_timeslice = (MSEC_PER_SEC / HZ) * RR_TIMESLICE;
+ static int sysctl_sched_rr_timeslice = (MSEC_PER_SEC * RR_TIMESLICE) / HZ;
 -- 
-2.28.0
+2.55.0
 
 
-From acc49f33a10f61dc66c423888cbb883ba46710e4 Mon Sep 17 00:00:00 2001
+From cd78e17b384f675a7bf3c3750ed1a4396aa5835b Mon Sep 17 00:00:00 2001
 From: Alexandre Frade <admfrade@gmail.com>
 Date: Mon, 29 Jan 2018 17:41:29 +0000
-Subject: [PATCH 04/17] scripts: disable the localversion "+" tag of a git repo
+Subject: [PATCH 03/21] scripts: disable the localversion "+" tag of a git repo
 
 Signed-off-by: Alexandre Frade <admfrade@gmail.com>
 ---
@@ -83,10 +80,10 @@ Signed-off-by: Alexandre Frade <admfrade@gmail.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/scripts/setlocalversion b/scripts/setlocalversion
-index 20f2efd57b11..0552d8b9f582 100755
+index 28169d7e1..5cb02894a 100755
 --- a/scripts/setlocalversion
 +++ b/scripts/setlocalversion
-@@ -54,7 +54,7 @@ scm_version()
+@@ -117,7 +117,7 @@ scm_version()
  		# If only the short version is requested, don't bother
  		# running further git commands
  		if $short; then
@@ -94,15 +91,15 @@ index 20f2efd57b11..0552d8b9f582 100755
 +			#echo "+"
  			return
  		fi
- 		# If we are past the tagged commit, we pretty print it.
+ 
 -- 
-2.28.0
+2.55.0
 
 
-From 360c6833e07cc9fdef5746f6bc45bdbc7212288d Mon Sep 17 00:00:00 2001
+From 75a53a35ccfed50bb027de41d5440d4adad2179b Mon Sep 17 00:00:00 2001
 From: "Jan Alexander Steffens (heftig)" <jan.steffens@gmail.com>
 Date: Fri, 26 Oct 2018 11:22:33 +0100
-Subject: [PATCH 06/17] infiniband: Fix __read_overflow2 error with -O3
+Subject: [PATCH 04/21] infiniband: Fix __read_overflow2 error with -O3
  inlining
 
 ---
@@ -110,10 +107,10 @@ Subject: [PATCH 06/17] infiniband: Fix __read_overflow2 error with -O3
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/infiniband/core/addr.c b/drivers/infiniband/core/addr.c
-index 3a98439bba83..6efc4f907f58 100644
+index 27992c38a..25b598bc6 100644
 --- a/drivers/infiniband/core/addr.c
 +++ b/drivers/infiniband/core/addr.c
-@@ -820,6 +820,7 @@ int rdma_addr_find_l2_eth_by_grh(const union ib_gid *sgid,
+@@ -798,6 +798,7 @@ int rdma_addr_find_l2_eth_by_grh(const union ib_gid *sgid,
  	union {
  		struct sockaddr_in  _sockaddr_in;
  		struct sockaddr_in6 _sockaddr_in6;
@@ -122,23 +119,23 @@ index 3a98439bba83..6efc4f907f58 100644
  	int ret;
  
 -- 
-2.28.0
+2.55.0
 
 
-From f85ed068b4d0e6c31edce8574a95757a60e58b87 Mon Sep 17 00:00:00 2001
+From 663f71ac387453c71776e335d0199279161f63aa Mon Sep 17 00:00:00 2001
 From: Etienne Juvigny <Ti3noU@gmail.com>
 Date: Mon, 3 Sep 2018 17:36:25 +0200
-Subject: [PATCH 07/17] Add Zenify option
+Subject: [PATCH 05/21] Add Zenify option
 
 ---
- init/Kconfig           | 32 ++++++++++++++++++++++++++++++++
- 1 file changed, 32 insertions(+)
+ init/Kconfig | 39 +++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 39 insertions(+)
 
 diff --git a/init/Kconfig b/init/Kconfig
-index 3ae8678e1145..da708eed0f1e 100644
+index 2937c4d30..f0329f93c 100644
 --- a/init/Kconfig
 +++ b/init/Kconfig
-@@ -92,6 +92,38 @@ config THREAD_INFO_IN_TASK
+@@ -215,6 +215,45 @@ config THREAD_INFO_IN_TASK
  
  menu "General setup"
  
@@ -152,11 +149,14 @@ index 3ae8678e1145..da708eed0f1e 100644
 +
 +	    Mem dirty before bg writeback..:  10 %  ->  20 %
 +	    Mem dirty before sync writeback:  20 %  ->  50 %
++	    Watermark boost factor.........:   1.5  ->   0
++	    Swap-in readahead..............:   3    ->   0
 +
 +	  --- Block Layer ----------------------------------------
 +
 +	    Queue depth...............:      128    -> 512
-+	    Default MQ scheduler......: mq-deadline -> bfq
++	    Default scheduler for SQ..: mq-deadline -> bfq
++	    Default scheduler for MQ..:        none -> kyber
 +
 +	  --- CFS CPU Scheduler ----------------------------------
 +
@@ -174,17 +174,21 @@ index 3ae8678e1145..da708eed0f1e 100644
 +	    Ondemand coarse upscaling limit:  80 %  ->  45 %
 +	    Ondemand fine upscaling limit..:  95 %  ->  45 %
 +
++	  --- Split/Bus lock detection --------------------------
++
++	    Split lock mitigation..........:   1    ->   0
++
  config BROKEN
  	bool
- 
+ 	help
 -- 
-2.28.0
+2.55.0
 
 
-From e92e67143385cf285851e12aa8b7f083dd38dd24 Mon Sep 17 00:00:00 2001
+From 2526bd754b481afe0d68c257335bd1eceea1fd05 Mon Sep 17 00:00:00 2001
 From: Steven Barrett <damentz@liquorix.net>
 Date: Sun, 16 Jan 2011 18:57:32 -0600
-Subject: [PATCH 08/17] ZEN: Allow TCP YeAH as default congestion control
+Subject: [PATCH 06/21] ZEN: Allow TCP YeAH as default congestion control
 
 4.4: In my tests YeAH dramatically slowed down transfers over a WLAN,
      reducing throughput from ~65Mbps (CUBIC) to ~7MBps (YeAH) over 10
@@ -196,10 +200,10 @@ Subject: [PATCH 08/17] ZEN: Allow TCP YeAH as default congestion control
  1 file changed, 4 insertions(+)
 
 diff --git a/net/ipv4/Kconfig b/net/ipv4/Kconfig
-index e64e59b536d3..bfb55ef7ebbe 100644
+index 21e5164e3..633e68703 100644
 --- a/net/ipv4/Kconfig
 +++ b/net/ipv4/Kconfig
-@@ -691,6 +691,9 @@ choice
+@@ -700,6 +700,9 @@ choice
  	config DEFAULT_VEGAS
  		bool "Vegas" if TCP_CONG_VEGAS=y
  
@@ -209,7 +213,7 @@ index e64e59b536d3..bfb55ef7ebbe 100644
  	config DEFAULT_VENO
  		bool "Veno" if TCP_CONG_VENO=y
  
-@@ -724,6 +727,7 @@ config DEFAULT_TCP_CONG
+@@ -733,6 +736,7 @@ config DEFAULT_TCP_CONG
  	default "htcp" if DEFAULT_HTCP
  	default "hybla" if DEFAULT_HYBLA
  	default "vegas" if DEFAULT_VEGAS
@@ -218,13 +222,13 @@ index e64e59b536d3..bfb55ef7ebbe 100644
  	default "veno" if DEFAULT_VENO
  	default "reno" if DEFAULT_RENO
 -- 
-2.28.0
+2.55.0
 
 
-From 76dbe7477bfde1b5e8bf29a71b5af7ab2be9b98e Mon Sep 17 00:00:00 2001
+From 586694922b294179f45006b95d1d5171560f8ddc Mon Sep 17 00:00:00 2001
 From: Steven Barrett <steven@liquorix.net>
 Date: Wed, 28 Nov 2018 19:01:27 -0600
-Subject: [PATCH 09/17] zen: Use [defer+madvise] as default khugepaged defrag
+Subject: [PATCH 07/21] zen: Use [defer+madvise] as default khugepaged defrag
  strategy
 
 For some reason, the default strategy to respond to THP fault fallbacks
@@ -252,10 +256,10 @@ Reasoning and details in the original patch: https://lwn.net/Articles/711248/
  1 file changed, 4 insertions(+)
 
 diff --git a/mm/huge_memory.c b/mm/huge_memory.c
-index 74300e337c3c..9277f22c10a7 100644
+index b118bcd39..8c3dd0f67 100644
 --- a/mm/huge_memory.c
 +++ b/mm/huge_memory.c
-@@ -53,7 +53,11 @@ unsigned long transparent_hugepage_flags __read_mostly =
+@@ -63,7 +63,11 @@ unsigned long transparent_hugepage_flags __read_mostly =
  #ifdef CONFIG_TRANSPARENT_HUGEPAGE_MADVISE
  	(1<<TRANSPARENT_HUGEPAGE_REQ_MADV_FLAG)|
  #endif
@@ -268,13 +272,13 @@ index 74300e337c3c..9277f22c10a7 100644
  	(1<<TRANSPARENT_HUGEPAGE_USE_ZERO_PAGE_FLAG);
  
 -- 
-2.28.0
+2.55.0
 
 
-From 2b65a1329cb220b43c19c4d0de5833fae9e2b22d Mon Sep 17 00:00:00 2001
+From 125f1967f4898ca405bfadc93b723a3dde325e7d Mon Sep 17 00:00:00 2001
 From: Alexandre Frade <admfrade@gmail.com>
 Date: Wed, 24 Oct 2018 16:58:52 -0300
-Subject: [PATCH 10/17] net/sched: allow configuring cake qdisc as default
+Subject: [PATCH 08/21] net/sched: allow configuring cake qdisc as default
 
 Signed-off-by: Alexandre Frade <admfrade@gmail.com>
 ---
@@ -282,10 +286,10 @@ Signed-off-by: Alexandre Frade <admfrade@gmail.com>
  1 file changed, 4 insertions(+)
 
 diff --git a/net/sched/Kconfig b/net/sched/Kconfig
-index 84badf00647e..6a922bca9f39 100644
+index 6ddff028b..2c0fe1858 100644
 --- a/net/sched/Kconfig
 +++ b/net/sched/Kconfig
-@@ -471,6 +471,9 @@ choice
+@@ -462,6 +462,9 @@ choice
  	config DEFAULT_SFQ
  		bool "Stochastic Fair Queue" if NET_SCH_SFQ
  
@@ -295,118 +299,397 @@ index 84badf00647e..6a922bca9f39 100644
  	config DEFAULT_PFIFO_FAST
  		bool "Priority FIFO Fast"
  endchoice
-@@ -481,6 +484,7 @@ config DEFAULT_NET_SCH
- 	default "fq" if DEFAULT_FQ
+@@ -473,6 +476,7 @@ config DEFAULT_NET_SCH
  	default "fq_codel" if DEFAULT_FQ_CODEL
+ 	default "fq_pie" if DEFAULT_FQ_PIE
  	default "sfq" if DEFAULT_SFQ
 +	default "cake" if DEFAULT_CAKE
  	default "pfifo_fast"
  endif
  
 -- 
-2.28.0
+2.55.0
 
 
-From 90240bcd90a568878738e66c0d45bed3e38e347b Mon Sep 17 00:00:00 2001
-From: Tk-Glitch <ti3nou@gmail.com>
-Date: Fri, 19 Apr 2019 12:33:38 +0200
-Subject: [PATCH 12/17] Set vm.max_map_count to 262144 by default
+From 5862ecc17fb7dcc7489136ff5afbf1284f8d11ae Mon Sep 17 00:00:00 2001
+From: Steven Barrett <steven@liquorix.net>
+Date: Thu, 27 Apr 2023 14:43:57 -0500
+Subject: [PATCH 09/21] ZEN: Set default max map count to (INT_MAX - 5)
 
-The value is still pretty low, and AMD64-ABI and ELF extended numbering
-supports that, so we should be fine on modern x86 systems.
+Per [Fedora][1], they intend to change the default max map count for
+their distribution to improve OOTB compatibility with games played
+through Steam/Proton.  The value they picked comes from the Steam Deck,
+which defaults to INT_MAX - MAPCOUNT_ELF_CORE_MARGIN.
 
-This fixes crashes in some applications using more than 65535 vmas (also
-affects some windows games running in wine, such as Star Citizen).
----
- include/linux/mm.h | 3 +--
- 1 file changed, 1 insertion(+), 2 deletions(-)
+Since most ZEN and Liquorix users probably play games, follow Valve's
+lead and raise this value to their default.
 
-diff --git a/include/linux/mm.h b/include/linux/mm.h
-index bc05c3588aa3..b0cefe94920d 100644
---- a/include/linux/mm.h
-+++ b/include/linux/mm.h
-@@ -190,8 +190,7 @@ static inline void __mm_zero_struct_page(struct page *page)
-  * not a hard limit any more. Although some userspace tools can be surprised by
-  * that.
-  */
--#define MAPCOUNT_ELF_CORE_MARGIN	(5)
--#define DEFAULT_MAX_MAP_COUNT	(USHRT_MAX - MAPCOUNT_ELF_CORE_MARGIN)
-+#define DEFAULT_MAX_MAP_COUNT	(262144)
- 
- extern int sysctl_max_map_count;
- 
--- 
-2.28.0
-
-
-From 3a34034dba5efe91bcec491efe8c66e8087f509b Mon Sep 17 00:00:00 2001
-From: Tk-Glitch <ti3nou@gmail.com>
-Date: Mon, 27 Jul 2020 00:19:18 +0200
-Subject: [PATCH 13/17] mm: bump DEFAULT_MAX_MAP_COUNT
-
-Some games such as Detroit: Become Human tend to be very crash prone with
-lower values.
+[1]: https://fedoraproject.org/wiki/Changes/IncreaseVmMaxMapCount
 ---
  include/linux/mm.h | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/include/linux/mm.h b/include/linux/mm.h
-index b0cefe94920d..890165099b07 100644
+index 80fce2515..05bbf4690 100644
 --- a/include/linux/mm.h
 +++ b/include/linux/mm.h
-@@ -190,7 +190,7 @@ static inline void __mm_zero_struct_page(struct page *page)
-  * not a hard limit any more. Although some userspace tools can be surprised by
+@@ -205,7 +205,7 @@ static inline void __mm_zero_struct_page(struct page *page)
   * that.
   */
--#define DEFAULT_MAX_MAP_COUNT	(262144)
-+#define DEFAULT_MAX_MAP_COUNT	(16777216)
+ #define MAPCOUNT_ELF_CORE_MARGIN	(5)
+-#define DEFAULT_MAX_MAP_COUNT	(USHRT_MAX - MAPCOUNT_ELF_CORE_MARGIN)
++#define DEFAULT_MAX_MAP_COUNT	(INT_MAX - MAPCOUNT_ELF_CORE_MARGIN)
  
- extern int sysctl_max_map_count;
+ extern unsigned long sysctl_user_reserve_kbytes;
+ extern unsigned long sysctl_admin_reserve_kbytes;
+-- 
+2.55.0
+
+
+From 765b79bb143d646f87d2407b656f99eb891f5c24 Mon Sep 17 00:00:00 2001
+From: Sultan Alsawaf <sultan@kerneltoast.com>
+Date: Sun, 19 Apr 2020 19:59:18 -0700
+Subject: [PATCH 10/21] ZEN: mm: Stop kswapd early when nothing's waiting for
+ it to free pages
+
+Contains:
+  - mm: Stop kswapd early when nothing's waiting for it to free pages
+
+    Keeping kswapd running when all the failed allocations that invoked it
+    are satisfied incurs a high overhead due to unnecessary page eviction
+    and writeback, as well as spurious VM pressure events to various
+    registered shrinkers. When kswapd doesn't need to work to make an
+    allocation succeed anymore, stop it prematurely to save resources.
+
+    Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
+
+  - mm: Don't stop kswapd on a per-node basis when there are no waiters
+
+    The page allocator wakes all kswapds in an allocation context's allowed
+    nodemask in the slow path, so it doesn't make sense to have the kswapd-
+    waiter count per each NUMA node. Instead, it should be a global counter
+    to stop all kswapds when there are no failed allocation requests.
+
+    Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
+
+  - mm: Increment kswapd_waiters for throttled direct reclaimers
+
+    Throttled direct reclaimers will wake up kswapd and wait for kswapd to
+    satisfy their page allocation request, even when the failed allocation
+    lacks the __GFP_KSWAPD_RECLAIM flag in its gfp mask. As a result, kswapd
+    may think that there are no waiters and thus exit prematurely, causing
+    throttled direct reclaimers lacking __GFP_KSWAPD_RECLAIM to stall on
+    waiting for kswapd to wake them up. Incrementing the kswapd_waiters
+    counter when such direct reclaimers become throttled fixes the problem.
+
+    Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
+---
+ mm/internal.h   |  1 +
+ mm/page_alloc.c | 17 ++++++++++++++---
+ mm/vmscan.c     | 19 +++++++++++++------
+ 3 files changed, 28 insertions(+), 9 deletions(-)
+
+diff --git a/mm/internal.h b/mm/internal.h
+index 5a2ddcf68..eaf2ba612 100644
+--- a/mm/internal.h
++++ b/mm/internal.h
+@@ -920,6 +920,7 @@ void post_alloc_hook(struct page *page, unsigned int order, gfp_t gfp_flags);
+ extern bool free_pages_prepare(struct page *page, unsigned int order);
+ 
+ extern int user_min_free_kbytes;
++extern atomic_long_t kswapd_waiters;
+ 
+ struct page *__alloc_frozen_pages_noprof(gfp_t, unsigned int order, int nid,
+ 		nodemask_t *);
+diff --git a/mm/page_alloc.c b/mm/page_alloc.c
+index d49c25417..649af6571 100644
+--- a/mm/page_alloc.c
++++ b/mm/page_alloc.c
+@@ -90,6 +90,8 @@ typedef int __bitwise fpi_t;
+ /* Free the page without taking locks. Rely on trylock only. */
+ #define FPI_TRYLOCK		((__force fpi_t)BIT(2))
+ 
++atomic_long_t kswapd_waiters = ATOMIC_LONG_INIT(0);
++
+ /* prevent >1 _updater_ of zone percpu pageset ->high and ->batch fields */
+ static DEFINE_MUTEX(pcp_batch_high_lock);
+ #define MIN_PERCPU_PAGELIST_HIGH_FRACTION (8)
+@@ -4698,6 +4700,7 @@ __alloc_pages_slowpath(gfp_t gfp_mask, unsigned int order,
+ 	int reserve_flags;
+ 	bool compact_first = false;
+ 	bool can_retry_reserves = true;
++	bool woke_kswapd = false;
+ 
+ 	if (unlikely(nofail)) {
+ 		/*
+@@ -4767,8 +4770,13 @@ __alloc_pages_slowpath(gfp_t gfp_mask, unsigned int order,
+ 
+ retry:
+ 	/* Ensure kswapd doesn't accidentally go to sleep as long as we loop */
+-	if (alloc_flags & ALLOC_KSWAPD)
++	if (alloc_flags & ALLOC_KSWAPD) {
++		if (!woke_kswapd) {
++			atomic_long_inc(&kswapd_waiters);
++			woke_kswapd = true;
++		}
+ 		wake_all_kswapds(order, gfp_mask, ac);
++	}
+ 
+ 	/*
+ 	 * The adjusted alloc_flags might result in immediate success, so try
+@@ -4959,9 +4967,12 @@ __alloc_pages_slowpath(gfp_t gfp_mask, unsigned int order,
+ 		goto retry;
+ 	}
+ fail:
+-	warn_alloc(gfp_mask, ac->nodemask,
+-			"page allocation failure: order:%u", order);
+ got_pg:
++	if (woke_kswapd)
++		atomic_long_dec(&kswapd_waiters);
++	if (!page)
++		warn_alloc(gfp_mask, ac->nodemask,
++				"page allocation failure: order:%u", order);
+ 	return page;
+ }
+ 
+diff --git a/mm/vmscan.c b/mm/vmscan.c
+index bd1b1aa12..34e0e1a21 100644
+--- a/mm/vmscan.c
++++ b/mm/vmscan.c
+@@ -6592,7 +6592,7 @@ static unsigned long do_try_to_free_pages(struct zonelist *zonelist,
+ 	return 0;
+ }
+ 
+-static bool allow_direct_reclaim(pg_data_t *pgdat)
++static bool allow_direct_reclaim(pg_data_t *pgdat, bool using_kswapd)
+ {
+ 	struct zone *zone;
+ 	unsigned long pfmemalloc_reserve = 0;
+@@ -6617,6 +6617,10 @@ static bool allow_direct_reclaim(pg_data_t *pgdat)
+ 
+ 	wmark_ok = free_pages > pfmemalloc_reserve / 2;
+ 
++	/* The throttled direct reclaimer is now a kswapd waiter */
++	if (unlikely(!using_kswapd && !wmark_ok))
++		atomic_long_inc(&kswapd_waiters);
++
+ 	/* kswapd must be awake if processes are being throttled */
+ 	if (!wmark_ok && waitqueue_active(&pgdat->kswapd_wait)) {
+ 		if (READ_ONCE(pgdat->kswapd_highest_zoneidx) > ZONE_NORMAL)
+@@ -6682,7 +6686,7 @@ static bool throttle_direct_reclaim(gfp_t gfp_mask, struct zonelist *zonelist,
+ 
+ 		/* Throttle based on the first usable node */
+ 		pgdat = zone->zone_pgdat;
+-		if (allow_direct_reclaim(pgdat))
++		if (allow_direct_reclaim(pgdat, gfp_mask & __GFP_KSWAPD_RECLAIM))
+ 			goto out;
+ 		break;
+ 	}
+@@ -6704,11 +6708,14 @@ static bool throttle_direct_reclaim(gfp_t gfp_mask, struct zonelist *zonelist,
+ 	 */
+ 	if (!(gfp_mask & __GFP_FS))
+ 		wait_event_interruptible_timeout(pgdat->pfmemalloc_wait,
+-			allow_direct_reclaim(pgdat), HZ);
++			allow_direct_reclaim(pgdat, true), HZ);
+ 	else
+ 		/* Throttle until kswapd wakes the process */
+ 		wait_event_killable(zone->zone_pgdat->pfmemalloc_wait,
+-			allow_direct_reclaim(pgdat));
++			allow_direct_reclaim(pgdat, true));
++
++	if (unlikely(!(gfp_mask & __GFP_KSWAPD_RECLAIM)))
++		atomic_long_dec(&kswapd_waiters);
+ 
+ 	if (fatal_signal_pending(current))
+ 		return true;
+@@ -7234,14 +7241,14 @@ static int balance_pgdat(pg_data_t *pgdat, int order, int highest_zoneidx)
+ 		 * able to safely make forward progress. Wake them
+ 		 */
+ 		if (waitqueue_active(&pgdat->pfmemalloc_wait) &&
+-				allow_direct_reclaim(pgdat))
++				allow_direct_reclaim(pgdat, true))
+ 			wake_up_all(&pgdat->pfmemalloc_wait);
+ 
+ 		/* Check if kswapd should be suspending */
+ 		__fs_reclaim_release(_THIS_IP_);
+ 		ret = kthread_freezable_should_stop(&was_frozen);
+ 		__fs_reclaim_acquire(_THIS_IP_);
+-		if (was_frozen || ret)
++		if (was_frozen || ret || !atomic_long_read(&kswapd_waiters))
+ 			break;
+ 
+ 		/*
+-- 
+2.55.0
+
+
+From 633e680706a6db99723e604654599984622e2a3f Mon Sep 17 00:00:00 2001
+From: Sultan Alsawaf <sultan@kerneltoast.com>
+Date: Sat, 28 Mar 2020 13:06:28 -0700
+Subject: [PATCH 11/21] ZEN: INTERACTIVE: mm: Disable watermark boosting by
+ default
+
+What watermark boosting does is preemptively fire up kswapd to free
+memory when there hasn't been an allocation failure. It does this by
+increasing kswapd's high watermark goal and then firing up kswapd. The
+reason why this causes freezes is because, with the increased high
+watermark goal, kswapd will steal memory from processes that need it in
+order to make forward progress. These processes will, in turn, try to
+allocate memory again, which will cause kswapd to steal necessary pages
+from those processes again, in a positive feedback loop known as page
+thrashing. When page thrashing occurs, your system is essentially
+livelocked until the necessary forward progress can be made to stop
+processes from trying to continuously allocate memory and trigger
+kswapd to steal it back.
+
+This problem already occurs with kswapd *without* watermark boosting,
+but it's usually only encountered on machines with a small amount of
+memory and/or a slow CPU. Watermark boosting just makes the existing
+problem worse enough to notice on higher spec'd machines.
+
+Disable watermark boosting by default since it's a total dumpster fire.
+I can't imagine why anyone would want to explicitly enable it, but the
+option is there in case someone does.
+
+tkg: Config switch changed to our local "ZENIFY" toggle
+
+Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
+---
+ mm/page_alloc.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/mm/page_alloc.c b/mm/page_alloc.c
+index 649af6571..ff40118f2 100644
+--- a/mm/page_alloc.c
++++ b/mm/page_alloc.c
+@@ -269,7 +269,11 @@ const char * const migratetype_names[MIGRATE_TYPES] = {
+ 
+ int min_free_kbytes = 1024;
+ int user_min_free_kbytes = -1;
++#ifdef CONFIG_ZENIFY
++static int watermark_boost_factor __read_mostly;
++#else
+ static int watermark_boost_factor __read_mostly = 15000;
++#endif
+ static int watermark_scale_factor = 10;
+ int defrag_mode;
  
 -- 
-2.28.0
+2.55.0
 
-From 977812938da7c7226415778c340832141d9278b7 Mon Sep 17 00:00:00 2001
+
+From 8037bc6b878dad8f5c4b9f7cfaaf175df6f91a65 Mon Sep 17 00:00:00 2001
+From: Steven Barrett <steven@liquorix.net>
+Date: Mon, 5 Sep 2022 11:35:20 -0500
+Subject: [PATCH 12/21] ZEN: INTERACTIVE: mm/swap: Disable swap-in readahead
+
+Per an [issue][1] on the chromium project, swap-in readahead causes more
+jank than not.  This might be caused by poor optimization on the
+swapping code, or the fact under memory pressure, we're pulling in pages
+we don't need, causing more swapping.
+
+Either way, this is mainline/upstream to Chromium, and ChromeOS
+developers care a lot about system responsiveness. Lets implement the
+same change so Zen Kernel users benefit.
+
+[1]: https://bugs.chromium.org/p/chromium/issues/detail?id=263561
+
+tkg: Config switch changed to our local "ZENIFY" toggle
+---
+ mm/swap.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/mm/swap.c b/mm/swap.c
+index 5cc44f0de..b46e7ad2d 100644
+--- a/mm/swap.c
++++ b/mm/swap.c
+@@ -1140,6 +1140,10 @@ static const struct ctl_table swap_sysctl_table[] = {
+  */
+ void __init swap_setup(void)
+ {
++#ifdef CONFIG_ZENIFY
++	/* Only swap-in pages requested, avoid readahead */
++	page_cluster = 0;
++#else
+ 	unsigned long megs = PAGES_TO_MB(totalram_pages());
+ 
+ 	/* Use a smaller cluster for small-memory machines */
+@@ -1151,6 +1155,7 @@ void __init swap_setup(void)
+ 	 * Right now other parts of the system means that we
+ 	 * _really_ don't want to cluster much more
+ 	 */
++#endif
+ 
+ 	register_sysctl_init("vm", swap_sysctl_table);
+ }
+-- 
+2.55.0
+
+
+From 495c78ff5b4573cdba918652b54a312769291b87 Mon Sep 17 00:00:00 2001
 From: Alexandre Frade <admfrade@gmail.com>
 Date: Mon, 25 Nov 2019 15:13:06 -0300
-Subject: [PATCH 14/17] elevator: set default scheduler to bfq for blk-mq
+Subject: [PATCH 13/21] elevator: set interactive default schedulers for blk-mq
 
 Signed-off-by: Alexandre Frade <admfrade@gmail.com>
 ---
- block/elevator.c | 6 +++---
- 1 file changed, 3 insertions(+), 3 deletions(-)
+ block/elevator.c | 23 ++++++++++++++++-------
+ 1 file changed, 16 insertions(+), 7 deletions(-)
 
 diff --git a/block/elevator.c b/block/elevator.c
-index 4eab3d70e880..79669aa39d79 100644
+index 3bcd37c2a..c22bcaa5e 100644
 --- a/block/elevator.c
 +++ b/block/elevator.c
-@@ -715,7 +715,7 @@  */
+@@ -729,7 +729,11 @@ void elv_update_nr_hw_queues(struct request_queue *q,
  void elevator_set_default(struct request_queue *q)
  {
  	struct elv_change_ctx ctx = {
--		.name = "mq-deadline",
++#if defined(CONFIG_ZENIFY) && defined(CONFIG_IOSCHED_BFQ)
 +		.name = "bfq",
++#else
+ 		.name = "mq-deadline",
++#endif
  		.no_uevent = true,
  	};
- 	int err = 0;
-@@ -728,8 +728,8 @@ void elevator_set_default(struct request_queue *q)
+ 	int err;
+@@ -745,17 +749,22 @@ void elevator_set_default(struct request_queue *q)
+ 	 * have multiple queues or mq-deadline is not available, default
+ 	 * to "none".
+ 	 */
++	if (q->nr_hw_queues != 1 && !blk_mq_is_shared_tags(q->tag_set->flags))
++#if defined(CONFIG_ZENIFY) && defined(CONFIG_MQ_IOSCHED_KYBER)
++		ctx.name = "kyber";
++#else
++		return;
++#endif
++
+ 	ctx.type = elevator_find_get(ctx.name);
+ 	if (!ctx.type)
  		return;
  
- 	/*
--	 * For single queue devices, default to using mq-deadline. If we
--	 * have multiple queues or mq-deadline is not available, default
-+	 * For single queue devices, default to using bfq. If we
-+	 * have multiple queues or bfq is not available, default
-	 * to "none".
-	 */
-	if (elevator_find_get(ctx.name) && (q->nr_hw_queues == 1 ||
+-	if ((q->nr_hw_queues == 1 ||
+-			blk_mq_is_shared_tags(q->tag_set->flags))) {
+-		err = elevator_change(q, &ctx);
+-		if (err < 0)
+-			pr_warn("\"%s\" elevator initialization, failed %d, falling back to \"none\"\n",
+-					ctx.name, err);
+-	}
++	err = elevator_change(q, &ctx);
++	if (err < 0)
++		pr_warn("\"%s\" elevator initialization, failed %d, falling back to \"none\"\n",
++				ctx.name, err);
++
+ 	elevator_put(ctx.type);
+ }
+ 
 -- 
-2.28.0
+2.55.0
 
-From 3c229f434aca65c4ca61772bc03c3e0370817b92 Mon Sep 17 00:00:00 2001
+
+From 306d1796dea79152f05b686bc8ef9418992d0816 Mon Sep 17 00:00:00 2001
 From: Alexandre Frade <kernel@xanmod.org>
 Date: Mon, 3 Aug 2020 17:05:04 +0000
-Subject: [PATCH 16/17] mm: set 2 megabytes for address_space-level file
+Subject: [PATCH 14/21] mm: set 2 megabytes for address_space-level file
  read-ahead pages size
 
 Signed-off-by: Alexandre Frade <kernel@xanmod.org>
@@ -415,26 +698,63 @@ Signed-off-by: Alexandre Frade <kernel@xanmod.org>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/include/linux/pagemap.h b/include/linux/pagemap.h
-index cf2468da68e9..007dea784451 100644
+index 31a848485..76476bf98 100644
 --- a/include/linux/pagemap.h
 +++ b/include/linux/pagemap.h
-@@ -655,7 +655,7 @@ int replace_page_cache_page(struct page *old, struct page *new, gfp_t gfp_mask);
- void delete_from_page_cache_batch(struct address_space *mapping,
- 				  struct pagevec *pvec);
+@@ -1365,7 +1365,7 @@ struct readahead_control {
+ 		._index = i,						\
+ 	}
  
 -#define VM_READAHEAD_PAGES	(SZ_128K / PAGE_SIZE)
-+#define VM_READAHEAD_PAGES	(SZ_2M / PAGE_SIZE)
++#define VM_READAHEAD_PAGES	(SZ_256K / PAGE_SIZE)
  
- void page_cache_sync_readahead(struct address_space *, struct file_ra_state *,
- 		struct file *, pgoff_t index, unsigned long req_count);
+ void page_cache_ra_unbounded(struct readahead_control *,
+ 		unsigned long nr_to_read, unsigned long lookahead_count);
 -- 
-2.28.0
+2.55.0
 
 
-From 716f41cf6631f3a85834dcb67b4ce99185b6387f Mon Sep 17 00:00:00 2001
+From 2847ff80d4ee037b3e3ef46ed87d72d057106519 Mon Sep 17 00:00:00 2001
+From: Steven Barrett <steven@liquorix.net>
+Date: Mon, 11 Jul 2022 19:10:30 -0500
+Subject: [PATCH 15/21] ZEN: cpufreq: Remove schedutil dependency on Intel/AMD
+ P-State drivers
+
+Although both P-State drivers depend on schedutil in Kconfig, both code
+bases do not use any schedutil code.  This arbitrarily enables schedutil
+when unwanted in some configurations.
+---
+ drivers/cpufreq/Kconfig.x86 | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/drivers/cpufreq/Kconfig.x86 b/drivers/cpufreq/Kconfig.x86
+index a9093cd5e..3a8d5b46b 100644
+--- a/drivers/cpufreq/Kconfig.x86
++++ b/drivers/cpufreq/Kconfig.x86
+@@ -9,7 +9,6 @@ config X86_INTEL_PSTATE
+ 	select ACPI_PROCESSOR if ACPI
+ 	select ACPI_CPPC_LIB if X86_64 && ACPI && SCHED_MC_PRIO
+ 	select CPU_FREQ_GOV_PERFORMANCE
+-	select CPU_FREQ_GOV_SCHEDUTIL if SMP
+ 	help
+ 	  This driver provides a P state for Intel core processors.
+ 	  The driver implements an internal governor and will become
+@@ -39,7 +38,6 @@ config X86_AMD_PSTATE
+ 	depends on X86 && ACPI
+ 	select ACPI_PROCESSOR
+ 	select ACPI_CPPC_LIB if X86_64
+-	select CPU_FREQ_GOV_SCHEDUTIL if SMP
+ 	select ACPI_PLATFORM_PROFILE
+ 	select POWER_SUPPLY
+ 	help
+-- 
+2.55.0
+
+
+From 924d4ac07e98e7d0f9d4186cd77c71a9b84b378d Mon Sep 17 00:00:00 2001
 From: Steven Barrett <steven@liquorix.net>
 Date: Wed, 15 Jan 2020 20:43:56 -0600
-Subject: [PATCH 17/17] ZEN: intel-pstate: Implement "enable" parameter
+Subject: [PATCH 16/21] ZEN: intel-pstate: Implement "enable" parameter
 
 If intel-pstate is compiled into the kernel, it will preempt the loading
 of acpi-cpufreq so you can take advantage of hardware p-states without
@@ -462,39 +782,40 @@ selection.
  2 files changed, 5 insertions(+)
 
 diff --git a/Documentation/admin-guide/kernel-parameters.txt b/Documentation/admin-guide/kernel-parameters.txt
-index fb95fad81c79..3e92fee81e33 100644
+index 97007f4f6..aa6aa647f 100644
 --- a/Documentation/admin-guide/kernel-parameters.txt
 +++ b/Documentation/admin-guide/kernel-parameters.txt
-@@ -1857,6 +1857,9 @@
+@@ -2495,6 +2495,9 @@ Kernel parameters
  			disable
  			  Do not enable intel_pstate as the default
  			  scaling driver for the supported processors
 +			enable
 +			  Enable intel_pstate in-case "disable" was passed
 +			  previously in the kernel boot parameters
- 			passive
- 			  Use intel_pstate as a scaling driver, but configure it
- 			  to work with generic cpufreq governors (instead of
+                         active
+                           Use intel_pstate driver to bypass the scaling
+                           governors layer of cpufreq and provides it own
 diff --git a/drivers/cpufreq/intel_pstate.c b/drivers/cpufreq/intel_pstate.c
-index 36a469150ff9..aee891c9b78a 100644
+index 1f093e346..e744495c8 100644
 --- a/drivers/cpufreq/intel_pstate.c
 +++ b/drivers/cpufreq/intel_pstate.c
-@@ -2845,6 +2845,8 @@ static int __init intel_pstate_setup(char *str)
- 		if (!strcmp(str, "no_hwp"))
- 		no_hwp = 1;
-
+@@ -3917,6 +3917,8 @@ static int __init intel_pstate_setup(char *str)
+ 
+ 	if (!strcmp(str, "disable"))
+ 		no_load = 1;
 +	if (!strcmp(str, "enable"))
 +		no_load = 0;
- 	if (!strcmp(str, "force"))
- 		force_load = 1;
- 	if (!strcmp(str, "hwp_only"))
+ 	else if (!strcmp(str, "active"))
+ 		default_driver = &intel_pstate;
+ 	else if (!strcmp(str, "passive"))
 -- 
-2.28.0
+2.55.0
 
-From 379cbab18b5c75c622b93e2c5abdfac141fe9654 Mon Sep 17 00:00:00 2001
+
+From 301bb785507531ad2f1a8346396f9465853d626a Mon Sep 17 00:00:00 2001
 From: Kenny Levinsen <kl@kl.wtf>
 Date: Sun, 27 Dec 2020 14:43:13 +0000
-Subject: [PATCH] ZEN: Input: evdev - use call_rcu when detaching client
+Subject: [PATCH 17/21] ZEN: Input: evdev - use call_rcu when detaching client
 
 Significant time was spent on synchronize_rcu in evdev_detach_client
 when applications closed evdev devices. Switching VT away from a
@@ -535,7 +856,7 @@ Signed-off-by: Kenny Levinsen <kl@kl.wtf>
  1 file changed, 11 insertions(+), 8 deletions(-)
 
 diff --git a/drivers/input/evdev.c b/drivers/input/evdev.c
-index 95f90699d2b17b..2b10fe29d2c8d9 100644
+index c7325226c..4f18a50ea 100644
 --- a/drivers/input/evdev.c
 +++ b/drivers/input/evdev.c
 @@ -46,6 +46,7 @@ struct evdev_client {
@@ -546,10 +867,10 @@ index 95f90699d2b17b..2b10fe29d2c8d9 100644
  	enum input_clock_type clk_type;
  	bool revoked;
  	unsigned long *evmasks[EV_CNT];
-@@ -377,13 +378,22 @@ static void evdev_attach_client(struct evdev *evdev,
+@@ -368,13 +369,22 @@ static void evdev_attach_client(struct evdev *evdev,
  	spin_unlock(&evdev->client_lock);
  }
-
+ 
 +static void evdev_reclaim_client(struct rcu_head *rp)
 +{
 +	struct evdev_client *client = container_of(rp, struct evdev_client, rcu);
@@ -568,48 +889,54 @@ index 95f90699d2b17b..2b10fe29d2c8d9 100644
 -	synchronize_rcu();
 +	call_rcu(&client->rcu, evdev_reclaim_client);
  }
-
+ 
  static int evdev_open_device(struct evdev *evdev)
-@@ -436,7 +446,6 @@ static int evdev_release(struct inode *inode, struct file *file)
+@@ -427,7 +437,6 @@ static int evdev_release(struct inode *inode, struct file *file)
  {
  	struct evdev_client *client = file->private_data;
  	struct evdev *evdev = client->evdev;
 -	unsigned int i;
-
+ 
  	mutex_lock(&evdev->mutex);
-
-@@ -448,11 +457,6 @@ static int evdev_release(struct inode *inode, struct file *file)
-
+ 
+@@ -439,11 +448,6 @@ static int evdev_release(struct inode *inode, struct file *file)
+ 
  	evdev_detach_client(evdev, client);
-
+ 
 -	for (i = 0; i < EV_CNT; ++i)
 -		bitmap_free(client->evmasks[i]);
 -
 -	kvfree(client);
 -
  	evdev_close_device(evdev);
-
+ 
  	return 0;
-@@ -495,7 +499,6 @@ static int evdev_open(struct inode *inode, struct file *file)
-
+@@ -486,7 +490,6 @@ static int evdev_open(struct inode *inode, struct file *file)
+ 
   err_free_client:
  	evdev_detach_client(evdev, client);
 -	kvfree(client);
  	return error;
  }
+ 
+-- 
+2.55.0
 
 
-From f997578464b2c4c63e7bd1afbfef56212ee44f2d Mon Sep 17 00:00:00 2001
+From 3acb258fdca71e226db3b0533e59ed0d62c03ffa Mon Sep 17 00:00:00 2001
 From: Etienne JUVIGNY <ti3nou@gmail.com>
 Date: Mon, 6 Mar 2023 13:54:09 +0100
-Subject: Don't add -dirty versioning on unclean trees
+Subject: [PATCH 18/21] Don't add -dirty versioning on unclean trees
 
+---
+ scripts/setlocalversion | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
 
 diff --git a/scripts/setlocalversion b/scripts/setlocalversion
-index ca5795e16..ad0d94477 100755
+index 5cb02894a..6fe69fcc9 100755
 --- a/scripts/setlocalversion
 +++ b/scripts/setlocalversion
-@@ -85,12 +85,12 @@ scm_version()
+@@ -145,12 +145,12 @@ scm_version()
  	# git-diff-index does not refresh the index, so it may give misleading
  	# results.
  	# See git-update-index(1), git-diff-index(1), and git-status(1).
@@ -626,13 +953,17 @@ index ca5795e16..ad0d94477 100755
 +	#	printf '%s' -dirty
 +	#fi
  }
-
+ 
  collect_files()
+-- 
+2.55.0
 
-From 1cf70fdd26245554ab30234722338d8160dff394 Mon Sep 17 00:00:00 2001
+
+From d77e7c09819454800c192b030580176d4536fde1 Mon Sep 17 00:00:00 2001
 From: Steven Barrett <steven@liquorix.net>
 Date: Sat, 21 May 2022 15:15:09 -0500
-Subject: [PATCH] ZEN: INTERACTIVE: dm-crypt: Disable workqueues for crypto ops
+Subject: [PATCH 19/21] ZEN: INTERACTIVE: dm-crypt: Disable workqueues for
+ crypto ops
 
 Queueing in dm-crypt for crypto operations reduces performance on modern
 systems.  As discussed in an article from Cloudflare, they discovered
@@ -648,17 +979,16 @@ Fixes: https://github.com/zen-kernel/zen-kernel/issues/282
 tkg: Config switch changed to our local "ZENIFY" toggle
 ---
  drivers/md/dm-crypt.c | 5 +++++
- init/Kconfig          | 1 +
- 2 files changed, 6 insertions(+)
+ 1 file changed, 5 insertions(+)
 
 diff --git a/drivers/md/dm-crypt.c b/drivers/md/dm-crypt.c
-index 2ae8560b6a14ad..cb49218030c88b 100644
+index 608b617fb..7f9a6adb6 100644
 --- a/drivers/md/dm-crypt.c
 +++ b/drivers/md/dm-crypt.c
-@@ -3242,6 +3242,11 @@ static int crypt_ctr(struct dm_target *ti, unsigned int argc, char **argv)
+@@ -3226,6 +3226,11 @@ static int crypt_ctr(struct dm_target *ti, unsigned int argc, char **argv)
  			goto bad;
  	}
-
+ 
 +#ifdef CONFIG_ZENIFY
 +	set_bit(DM_CRYPT_NO_READ_WORKQUEUE, &cc->flags);
 +	set_bit(DM_CRYPT_NO_WRITE_WORKQUEUE, &cc->flags);
@@ -667,3 +997,447 @@ index 2ae8560b6a14ad..cb49218030c88b 100644
  	ret = crypt_ctr_cipher(ti, argv[0], argv[1]);
  	if (ret < 0)
  		goto bad;
+-- 
+2.55.0
+
+
+From d744d18082e1a2595299435448192c70f88a0e4c Mon Sep 17 00:00:00 2001
+From: Steven Barrett <steven@liquorix.net>
+Date: Sat, 14 Feb 2026 08:59:02 -0600
+Subject: [PATCH 20/21] ZEN: INTERACTIVE: Disable split lock mitigation by
+ default
+
+Split lock detection and mitigation is useful on multi tenant systems
+where the software interacting with the kernel may not be in control of
+the system owner.  Rate limiting bad code is important to reduce the
+effect of split locks on other tenants.
+
+However, most Zen Kernel users are running this kernel for just
+themselves and are unlikely to have multiple interactive sessions at
+once.
+
+Turn off split lock mitigation, by default so software that would
+otherwise be rate limited works as intended.
+
+tkg: Config switch changed to our local "ZENIFY" toggle
+---
+ arch/x86/kernel/cpu/bus_lock.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/arch/x86/kernel/cpu/bus_lock.c b/arch/x86/kernel/cpu/bus_lock.c
+index bba28607a..60c76d0d9 100644
+--- a/arch/x86/kernel/cpu/bus_lock.c
++++ b/arch/x86/kernel/cpu/bus_lock.c
+@@ -47,7 +47,11 @@ static const struct {
+ 
+ static struct ratelimit_state bld_ratelimit;
+ 
++#ifdef CONFIG_ZENIFY
++static unsigned int sysctl_sld_mitigate;
++#else
+ static unsigned int sysctl_sld_mitigate = 1;
++#endif
+ static DEFINE_SEMAPHORE(buslock_sem, 1);
+ 
+ #ifdef CONFIG_PROC_SYSCTL
+-- 
+2.55.0
+
+
+From 11e1aaaef5781d833141203edb3f10b201b2eb4c Mon Sep 17 00:00:00 2001
+From: Xie Yuanbin <qq570070308@gmail.com>
+Date: Sun, 23 Nov 2025 20:18:27 +0800
+Subject: [PATCH 21/21] ZEN: sched/core: Make finish_task_switch() and its
+ subfunctions always inline
+
+finish_task_switch() is a hot code path in context switching.
+When spectre_v2_user is enabled, kernel is likely to perform branch
+prediction hardening inside switch_mm_irqs_off(). finish_task_switch()
+is right after switch_mm_irqs_off(), so the performance here is
+greatly affected by function calls and branch jumps.
+
+Make finish_task_switch() always inline to optimize performance.
+
+After finish_task_switch() is changed as always inline, the number of
+calling points of subfunctions increases. According to the compiler
+optimization strategy, subfunctions that were originally inline may no
+longer be inline.
+
+Also make the subfunctions of finish_task_stwitch() always inline to
+prevent performance degradation.
+
+There is a improvement in the performace of finish_task_switch(). When
+spectre v2 is enabled, the improvement is significant.
+
+The following are testing results from intel i5-8300h@4Ghz (x86):
+Time spent on calling finish_task_switch(), the unit is tsc from x86:
+ | test scenario             | old   | new   | delta          |
+ | gcc 15.2                  | 13.94 | 12.40 | 1.54  (-11.1%) |
+ | gcc 15.2 + spectre_v2     | 24.78 | 13.70 | 11.08 (-44.7%) |
+ | clang 21.1.4              | 13.90 | 12.71 | 1.19  (- 8.6%) |
+ | clang 21.1.4 + spectre_v2 | 29.01 | 18.91 | 10.1  (-34.8%) |
+
+There is a minor improvement in the size of .text section in vmlinux,
+the unit is bytes:
+ | test scenario             | old      | new      | delta |
+ | gcc 15.2                  | 16208096 | 16208736 | 640   |
+ | clang 21.1.4              | 17943328 | 17944224 | 896   |
+
+No size changes were found on bzImage.
+
+Signed-off-by: Xie Yuanbin <qq570070308@gmail.com>
+Cc: Thomas Gleixner <tglx@linutronix.de>
+Cc: Rik van Riel <riel@surriel.com>
+Cc: Segher Boessenkool <segher@kernel.crashing.org>
+Cc: David Hildenbrand (Red Hat) <david@kernel.org>
+Cc: Peter Zijlstra <peterz@infradead.org>
+Cc: H. Peter Anvin (Intel) <hpa@zytor.com>
+Cc: Arnd Bergmann <arnd@arndb.de>
+---
+ arch/arm/include/asm/mmu_context.h      |  2 +-
+ arch/riscv/include/asm/sync_core.h      |  2 +-
+ arch/s390/include/asm/mmu_context.h     |  2 +-
+ arch/sparc/include/asm/mmu_context_64.h |  2 +-
+ arch/x86/include/asm/sync_core.h        |  2 +-
+ include/linux/perf_event.h              |  2 +-
+ include/linux/sched/mm.h                | 10 +++++-----
+ include/linux/tick.h                    |  4 ++--
+ include/linux/vtime.h                   |  8 ++++----
+ kernel/sched/core.c                     | 14 +++++++-------
+ kernel/sched/sched.h                    | 20 ++++++++++----------
+ 11 files changed, 34 insertions(+), 34 deletions(-)
+
+diff --git a/arch/arm/include/asm/mmu_context.h b/arch/arm/include/asm/mmu_context.h
+index db2cb06aa..bebde469f 100644
+--- a/arch/arm/include/asm/mmu_context.h
++++ b/arch/arm/include/asm/mmu_context.h
+@@ -80,7 +80,7 @@ static inline void check_and_switch_context(struct mm_struct *mm,
+ #ifndef MODULE
+ #define finish_arch_post_lock_switch \
+ 	finish_arch_post_lock_switch
+-static inline void finish_arch_post_lock_switch(void)
++static __always_inline void finish_arch_post_lock_switch(void)
+ {
+ 	struct mm_struct *mm = current->mm;
+ 
+diff --git a/arch/riscv/include/asm/sync_core.h b/arch/riscv/include/asm/sync_core.h
+index 9153016da..2fe6b7fe6 100644
+--- a/arch/riscv/include/asm/sync_core.h
++++ b/arch/riscv/include/asm/sync_core.h
+@@ -6,7 +6,7 @@
+  * RISC-V implements return to user-space through an xRET instruction,
+  * which is not core serializing.
+  */
+-static inline void sync_core_before_usermode(void)
++static __always_inline void sync_core_before_usermode(void)
+ {
+ 	asm volatile ("fence.i" ::: "memory");
+ }
+diff --git a/arch/s390/include/asm/mmu_context.h b/arch/s390/include/asm/mmu_context.h
+index bd1ef5e2d..95d03be2c 100644
+--- a/arch/s390/include/asm/mmu_context.h
++++ b/arch/s390/include/asm/mmu_context.h
+@@ -93,7 +93,7 @@ static inline void switch_mm(struct mm_struct *prev, struct mm_struct *next,
+ }
+ 
+ #define finish_arch_post_lock_switch finish_arch_post_lock_switch
+-static inline void finish_arch_post_lock_switch(void)
++static __always_inline void finish_arch_post_lock_switch(void)
+ {
+ 	struct task_struct *tsk = current;
+ 	struct mm_struct *mm = tsk->mm;
+diff --git a/arch/sparc/include/asm/mmu_context_64.h b/arch/sparc/include/asm/mmu_context_64.h
+index 78bbacc14..d1967214e 100644
+--- a/arch/sparc/include/asm/mmu_context_64.h
++++ b/arch/sparc/include/asm/mmu_context_64.h
+@@ -160,7 +160,7 @@ static inline void arch_start_context_switch(struct task_struct *prev)
+ }
+ 
+ #define finish_arch_post_lock_switch	finish_arch_post_lock_switch
+-static inline void finish_arch_post_lock_switch(void)
++static __always_inline void finish_arch_post_lock_switch(void)
+ {
+ 	/* Restore the state of MCDPER register for the new process
+ 	 * just switched to.
+diff --git a/arch/x86/include/asm/sync_core.h b/arch/x86/include/asm/sync_core.h
+index 96bda4353..4b55fa353 100644
+--- a/arch/x86/include/asm/sync_core.h
++++ b/arch/x86/include/asm/sync_core.h
+@@ -93,7 +93,7 @@ static __always_inline void sync_core(void)
+  * to user-mode. x86 implements return to user-space through sysexit,
+  * sysrel, and sysretq, which are not core serializing.
+  */
+-static inline void sync_core_before_usermode(void)
++static __always_inline void sync_core_before_usermode(void)
+ {
+ 	/* With PTI, we unconditionally serialize before running user code. */
+ 	if (static_cpu_has(X86_FEATURE_PTI))
+diff --git a/include/linux/perf_event.h b/include/linux/perf_event.h
+index 48d851fbd..7c1dac8da 100644
+--- a/include/linux/perf_event.h
++++ b/include/linux/perf_event.h
+@@ -1632,7 +1632,7 @@ static inline void perf_event_task_migrate(struct task_struct *task)
+ 		task->sched_migrated = 1;
+ }
+ 
+-static inline void perf_event_task_sched_in(struct task_struct *prev,
++static __always_inline void perf_event_task_sched_in(struct task_struct *prev,
+ 					    struct task_struct *task)
+ {
+ 	if (static_branch_unlikely(&perf_sched_events))
+diff --git a/include/linux/sched/mm.h b/include/linux/sched/mm.h
+index 95d0040df..4a279ee2d 100644
+--- a/include/linux/sched/mm.h
++++ b/include/linux/sched/mm.h
+@@ -44,7 +44,7 @@ static inline void smp_mb__after_mmgrab(void)
+ 
+ extern void __mmdrop(struct mm_struct *mm);
+ 
+-static inline void mmdrop(struct mm_struct *mm)
++static __always_inline void mmdrop(struct mm_struct *mm)
+ {
+ 	/*
+ 	 * The implicit full barrier implied by atomic_dec_and_test() is
+@@ -71,14 +71,14 @@ static inline void __mmdrop_delayed(struct rcu_head *rhp)
+  * Invoked from finish_task_switch(). Delegates the heavy lifting on RT
+  * kernels via RCU.
+  */
+-static inline void mmdrop_sched(struct mm_struct *mm)
++static __always_inline void mmdrop_sched(struct mm_struct *mm)
+ {
+ 	/* Provides a full memory barrier. See mmdrop() */
+ 	if (atomic_dec_and_test(&mm->mm_count))
+ 		call_rcu(&mm->delayed_drop, __mmdrop_delayed);
+ }
+ #else
+-static inline void mmdrop_sched(struct mm_struct *mm)
++static __always_inline void mmdrop_sched(struct mm_struct *mm)
+ {
+ 	mmdrop(mm);
+ }
+@@ -104,7 +104,7 @@ static inline void mmdrop_lazy_tlb(struct mm_struct *mm)
+ 	}
+ }
+ 
+-static inline void mmdrop_lazy_tlb_sched(struct mm_struct *mm)
++static __always_inline void mmdrop_lazy_tlb_sched(struct mm_struct *mm)
+ {
+ 	if (IS_ENABLED(CONFIG_MMU_LAZY_TLB_REFCOUNT))
+ 		mmdrop_sched(mm);
+@@ -532,7 +532,7 @@ enum {
+ #include <asm/membarrier.h>
+ #endif
+ 
+-static inline void membarrier_mm_sync_core_before_usermode(struct mm_struct *mm)
++static __always_inline void membarrier_mm_sync_core_before_usermode(struct mm_struct *mm)
+ {
+ 	/*
+ 	 * The atomic_read() below prevents CSE. The following should
+diff --git a/include/linux/tick.h b/include/linux/tick.h
+index 738007d6f..df9934a60 100644
+--- a/include/linux/tick.h
++++ b/include/linux/tick.h
+@@ -177,7 +177,7 @@ extern cpumask_var_t tick_nohz_full_mask;
+ #ifdef CONFIG_NO_HZ_FULL
+ extern bool tick_nohz_full_running;
+ 
+-static inline bool tick_nohz_full_enabled(void)
++static __always_inline bool tick_nohz_full_enabled(void)
+ {
+ 	if (!context_tracking_enabled())
+ 		return false;
+@@ -301,7 +301,7 @@ static inline void __tick_nohz_task_switch(void) { }
+ static inline void tick_nohz_full_setup(cpumask_var_t cpumask) { }
+ #endif
+ 
+-static inline void tick_nohz_task_switch(void)
++static __always_inline void tick_nohz_task_switch(void)
+ {
+ 	if (tick_nohz_full_enabled())
+ 		__tick_nohz_task_switch();
+diff --git a/include/linux/vtime.h b/include/linux/vtime.h
+index 29dd5b91d..428464bb8 100644
+--- a/include/linux/vtime.h
++++ b/include/linux/vtime.h
+@@ -67,24 +67,24 @@ static __always_inline void vtime_account_guest_exit(void)
+  * For now vtime state is tied to context tracking. We might want to decouple
+  * those later if necessary.
+  */
+-static inline bool vtime_accounting_enabled(void)
++static __always_inline bool vtime_accounting_enabled(void)
+ {
+ 	return context_tracking_enabled();
+ }
+ 
+-static inline bool vtime_accounting_enabled_cpu(int cpu)
++static __always_inline bool vtime_accounting_enabled_cpu(int cpu)
+ {
+ 	return context_tracking_enabled_cpu(cpu);
+ }
+ 
+-static inline bool vtime_accounting_enabled_this_cpu(void)
++static __always_inline bool vtime_accounting_enabled_this_cpu(void)
+ {
+ 	return context_tracking_enabled_this_cpu();
+ }
+ 
+ extern void vtime_task_switch_generic(struct task_struct *prev);
+ 
+-static inline void vtime_task_switch(struct task_struct *prev)
++static __always_inline void vtime_task_switch(struct task_struct *prev)
+ {
+ 	if (vtime_accounting_enabled_this_cpu())
+ 		vtime_task_switch_generic(prev);
+diff --git a/kernel/sched/core.c b/kernel/sched/core.c
+index 091ee8d2b..2b9bbe39e 100644
+--- a/kernel/sched/core.c
++++ b/kernel/sched/core.c
+@@ -4958,7 +4958,7 @@ static inline void prepare_task(struct task_struct *next)
+ 	WRITE_ONCE(next->on_cpu, 1);
+ }
+ 
+-static inline void finish_task(struct task_struct *prev)
++static __always_inline void finish_task(struct task_struct *prev)
+ {
+ 	/*
+ 	 * This must be the very last reference to @prev from this CPU. After
+@@ -5002,7 +5002,7 @@ static void zap_balance_callbacks(struct rq *rq)
+ 	rq->balance_callback = found ? &balance_push_callback : NULL;
+ }
+ 
+-static void do_balance_callbacks(struct rq *rq, struct balance_callback *head)
++static __always_inline void do_balance_callbacks(struct rq *rq, struct balance_callback *head)
+ {
+ 	void (*func)(struct rq *rq);
+ 	struct balance_callback *next;
+@@ -5037,7 +5037,7 @@ struct balance_callback balance_push_callback = {
+ 	.func = balance_push,
+ };
+ 
+-static inline struct balance_callback *
++static __always_inline struct balance_callback *
+ __splice_balance_callbacks(struct rq *rq, bool split)
+ {
+ 	struct balance_callback *head = rq->balance_callback;
+@@ -5067,7 +5067,7 @@ struct balance_callback *splice_balance_callbacks(struct rq *rq)
+ 	return __splice_balance_callbacks(rq, true);
+ }
+ 
+-void __balance_callbacks(struct rq *rq, struct rq_flags *rf)
++__always_inline void __balance_callbacks(struct rq *rq, struct rq_flags *rf)
+ {
+ 	if (rf)
+ 		rq_unpin_lock(rq, rf);
+@@ -5111,7 +5111,7 @@ prepare_lock_switch(struct rq *rq, struct task_struct *next, struct rq_flags *rf
+ 	__acquire(__rq_lockp(this_rq()));
+ }
+ 
+-static inline void finish_lock_switch(struct rq *rq)
++static __always_inline void finish_lock_switch(struct rq *rq)
+ 	__releases(__rq_lockp(rq))
+ {
+ 	/*
+@@ -5145,7 +5145,7 @@ static inline void kmap_local_sched_out(void)
+ #endif
+ }
+ 
+-static inline void kmap_local_sched_in(void)
++static __always_inline void kmap_local_sched_in(void)
+ {
+ #ifdef CONFIG_KMAP_LOCAL
+ 	if (unlikely(current->kmap_ctrl.idx))
+@@ -5199,7 +5199,7 @@ prepare_task_switch(struct rq *rq, struct task_struct *prev,
+  * past. 'prev == current' is still correct but we need to recalculate this_rq
+  * because prev may have moved to another CPU.
+  */
+-static struct rq *finish_task_switch(struct task_struct *prev)
++static __always_inline struct rq *finish_task_switch(struct task_struct *prev)
+ 	__releases(__rq_lockp(this_rq()))
+ {
+ 	struct rq *rq = this_rq();
+diff --git a/kernel/sched/sched.h b/kernel/sched/sched.h
+index 9f63b15d3..4c11c9c89 100644
+--- a/kernel/sched/sched.h
++++ b/kernel/sched/sched.h
+@@ -1441,12 +1441,12 @@ static inline struct cpumask *sched_group_span(struct sched_group *sg);
+ 
+ DECLARE_STATIC_KEY_FALSE(__sched_core_enabled);
+ 
+-static inline bool sched_core_enabled(struct rq *rq)
++static __always_inline bool sched_core_enabled(struct rq *rq)
+ {
+ 	return static_branch_unlikely(&__sched_core_enabled) && rq->core_enabled;
+ }
+ 
+-static inline bool sched_core_disabled(void)
++static __always_inline bool sched_core_disabled(void)
+ {
+ 	return !static_branch_unlikely(&__sched_core_enabled);
+ }
+@@ -1455,7 +1455,7 @@ static inline bool sched_core_disabled(void)
+  * Be careful with this function; not for general use. The return value isn't
+  * stable unless you actually hold a relevant rq->__lock.
+  */
+-static inline raw_spinlock_t *rq_lockp(struct rq *rq)
++static __always_inline raw_spinlock_t *rq_lockp(struct rq *rq)
+ {
+ 	if (sched_core_enabled(rq))
+ 		return &rq->core->__lock;
+@@ -1463,7 +1463,7 @@ static inline raw_spinlock_t *rq_lockp(struct rq *rq)
+ 	return &rq->__lock;
+ }
+ 
+-static inline raw_spinlock_t *__rq_lockp(struct rq *rq)
++static __always_inline raw_spinlock_t *__rq_lockp(struct rq *rq)
+ 	__returns_ctx_lock(rq_lockp(rq)) /* alias them */
+ {
+ 	if (rq->core_enabled)
+@@ -1558,12 +1558,12 @@ static inline bool sched_core_disabled(void)
+ 	return true;
+ }
+ 
+-static inline raw_spinlock_t *rq_lockp(struct rq *rq)
++static __always_inline raw_spinlock_t *rq_lockp(struct rq *rq)
+ {
+ 	return &rq->__lock;
+ }
+ 
+-static inline raw_spinlock_t *__rq_lockp(struct rq *rq)
++static __always_inline raw_spinlock_t *__rq_lockp(struct rq *rq)
+ 	__returns_ctx_lock(rq_lockp(rq)) /* alias them */
+ {
+ 	return &rq->__lock;
+@@ -1618,26 +1618,26 @@ extern void raw_spin_rq_lock_nested(struct rq *rq, int subclass)
+ extern bool raw_spin_rq_trylock(struct rq *rq)
+ 	__cond_acquires(true, __rq_lockp(rq));
+ 
+-static inline void raw_spin_rq_lock(struct rq *rq)
++static __always_inline void raw_spin_rq_lock(struct rq *rq)
+ 	__acquires(__rq_lockp(rq))
+ {
+ 	raw_spin_rq_lock_nested(rq, 0);
+ }
+ 
+-static inline void raw_spin_rq_unlock(struct rq *rq)
++static __always_inline void raw_spin_rq_unlock(struct rq *rq)
+ 	__releases(__rq_lockp(rq))
+ {
+ 	raw_spin_unlock(rq_lockp(rq));
+ }
+ 
+-static inline void raw_spin_rq_lock_irq(struct rq *rq)
++static __always_inline void raw_spin_rq_lock_irq(struct rq *rq)
+ 	__acquires(__rq_lockp(rq))
+ {
+ 	local_irq_disable();
+ 	raw_spin_rq_lock(rq);
+ }
+ 
+-static inline void raw_spin_rq_unlock_irq(struct rq *rq)
++static __always_inline void raw_spin_rq_unlock_irq(struct rq *rq)
+ 	__releases(__rq_lockp(rq))
+ {
+ 	raw_spin_rq_unlock(rq);
+-- 
+2.55.0
+

--- a/linux-tkg-patches/7.1/0013-clang-polly.patch
+++ b/linux-tkg-patches/7.1/0013-clang-polly.patch
@@ -1,0 +1,156 @@
+From 836c16fbbd981fcf4f6b39faad2e7e7be13d5434 Mon Sep 17 00:00:00 2001
+From: Peter Jung <admin@ptr1337.dev>
+Date: Thu, 12 Dec 2024 17:28:45 +0100
+Subject: [PATCH 1/3] kbuild: Add support for Clang's polyhedral loop
+ optimizer.
+
+Polly is able to optimize various loops throughout the kernel for cache
+locality. A mathematical representation of the program, based on
+polyhedra, is analysed to find opportunistic optimisations in memory
+access patterns which then leads to loop transformations.
+
+Polly is not built with LLVM by default, and requires LLVM to be compiled
+with the Polly "project". This can be done by adding Polly to
+-DLLVM_ENABLE_PROJECTS, for example:
+
+-DLLVM_ENABLE_PROJECTS="clang;libcxx;libcxxabi;polly"
+
+Preliminary benchmarking seems to show an improvement of around two
+percent across perf benchmarks:
+
+Benchmark                         | Control    | Polly
+--------------------------------------------------------
+bonnie++ -x 2 -s 4096 -r 0        | 12.610s    | 12.547s
+perf bench futex requeue          | 33.553s    | 33.094s
+perf bench futex wake             |  1.032s    |  1.021s
+perf bench futex wake-parallel    |  1.049s    |  1.025s
+perf bench futex requeue          |  1.037s    |  1.020s
+
+Furthermore, Polly does not produce a much larger image size netting it
+to be a "free" optimisation. A comparison of a bzImage for a kernel with
+and without Polly is shown below:
+
+bzImage        | stat --printf="%s\n"
+-------------------------------------
+Control        | 9333728
+Polly          | 9345792
+
+Compile times were one percent different at best, which is well within
+the range of noise. Therefore, I can say with certainty that Polly has
+a minimal effect on compile times, if none.
+
+Signed-off-by: Peter Jung <admin@ptr1337.dev>
+---
+ Makefile     | 16 ++++++++++++++++
+ init/Kconfig | 13 +++++++++++++
+ 2 files changed, 29 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index 64c594bd7..5f0cb6238 100644
+--- a/Makefile
++++ b/Makefile
+@@ -870,6 +870,22 @@ endif
+ KBUILD_RUSTFLAGS += -Cdebug-assertions=$(if $(CONFIG_RUST_DEBUG_ASSERTIONS),y,n)
+ KBUILD_RUSTFLAGS += -Coverflow-checks=$(if $(CONFIG_RUST_OVERFLOW_CHECKS),y,n)
+ 
++ifdef CONFIG_POLLY_CLANG
++KBUILD_CFLAGS	+= -mllvm -polly \
++		   -mllvm -polly-ast-use-context \
++		   -mllvm -polly-invariant-load-hoisting \
++		   -mllvm -polly-opt-fusion=max \
++		   -mllvm -polly-run-inliner \
++		   -mllvm -polly-vectorizer=stripmine
++# Polly may optimise loops with dead paths beyound what the linker
++# can understand. This may negate the effect of the linker's DCE
++# so we tell Polly to perfom proven DCE on the loops it optimises
++# in order to preserve the overall effect of the linker's DCE.
++ifdef CONFIG_LD_DEAD_CODE_DATA_ELIMINATION
++KBUILD_CFLAGS	+= -mllvm -polly-run-dce
++endif
++endif
++
+ # Tell gcc to never replace conditional load with a non-conditional one
+ ifdef CONFIG_CC_IS_GCC
+ # gcc-10 renamed --param=allow-store-data-races=0 to
+diff --git a/init/Kconfig b/init/Kconfig
+index a20e6efd3..66adb2fc9 100644
+--- a/init/Kconfig
++++ b/init/Kconfig
+@@ -251,6 +251,19 @@ config BUILD_SALT
+ 	  This is mostly useful for distributions which want to ensure the
+ 	  build is unique between builds. It's safe to leave the default.
+ 
++config POLLY_CLANG
++	bool "Use Clang Polly optimizations"
++	depends on CC_IS_CLANG && $(cc-option,-mllvm -polly -fplugin=LLVMPolly.so)
++	depends on !COMPILE_TEST
++	help
++	  This option enables Clang's polyhedral loop optimizer known as
++	  Polly. Polly is able to optimize various loops throughout the
++	  kernel for cache locality. This requires a Clang toolchain
++	  compiled with support for Polly. More information can be found
++	  from Polly's website:
++
++	    https://polly.llvm.org
++
+ config HAVE_KERNEL_GZIP
+ 	bool
+ 
+-- 
+2.47.1
+
+
+From 8b5347cd5e745e8d0a68b28e55b48c62e6c0c513 Mon Sep 17 00:00:00 2001
+From: Username404-59 <w.iron.zombie@gmail.com>
+Date: Thu, 12 Dec 2024 21:25:40 +0100
+Subject: [PATCH 2/3] kbuild: Update old polly option
+
+Signed-off-by: Username404-59 <w.iron.zombie@gmail.com>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 5f0cb6238..fa433f1d9 100644
+--- a/Makefile
++++ b/Makefile
+@@ -874,7 +874,7 @@ ifdef CONFIG_POLLY_CLANG
+ KBUILD_CFLAGS	+= -mllvm -polly \
+ 		   -mllvm -polly-ast-use-context \
+ 		   -mllvm -polly-invariant-load-hoisting \
+-		   -mllvm -polly-opt-fusion=max \
++		   -mllvm -polly-loopfusion-greedy \
+ 		   -mllvm -polly-run-inliner \
+ 		   -mllvm -polly-vectorizer=stripmine
+ # Polly may optimise loops with dead paths beyound what the linker
+-- 
+2.47.1
+
+
+From 562335afe34f24f9940d198d536e941e326a9716 Mon Sep 17 00:00:00 2001
+From: Username404-59 <w.iron.zombie@gmail.com>
+Date: Thu, 12 Dec 2024 21:41:01 +0100
+Subject: [PATCH 3/3] kbuild: load polly llvm plugin
+
+Signed-off-by: Username404-59 <w.iron.zombie@gmail.com>
+---
+ Makefile | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index fa433f1d9..e8737f5ea 100644
+--- a/Makefile
++++ b/Makefile
+@@ -871,7 +871,8 @@ KBUILD_RUSTFLAGS += -Cdebug-assertions=$(if $(CONFIG_RUST_DEBUG_ASSERTIONS),y,n)
+ KBUILD_RUSTFLAGS += -Coverflow-checks=$(if $(CONFIG_RUST_OVERFLOW_CHECKS),y,n)
+ 
+ ifdef CONFIG_POLLY_CLANG
+-KBUILD_CFLAGS	+= -mllvm -polly \
++KBUILD_CFLAGS	+= -fplugin=LLVMPolly.so \
++		   -mllvm -polly \
+ 		   -mllvm -polly-ast-use-context \
+ 		   -mllvm -polly-invariant-load-hoisting \
+ 		   -mllvm -polly-loopfusion-greedy \
+-- 
+2.47.1
+

--- a/linux-tkg-patches/7.1/0013-optimize_harder_O3.patch
+++ b/linux-tkg-patches/7.1/0013-optimize_harder_O3.patch
@@ -1,29 +1,39 @@
-From f5759c25a0ccbf8cf33ba661d5c6839259bc1d61 Mon Sep 17 00:00:00 2001
-From: Frogging-Family
-From: damachine <damachin3@proton.me>
+From 6686bca77194164171a7f362122203d2f79280e7 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Christian=20K=C3=BChn?= <damachin3@proton.me>
 Date: Wed, 15 Apr 2026 21:55:26 +0200
-Subject: [PATCH] Add compiler optimization option
+Subject: [PATCH] Add O3 compiler optimization options
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 Add CONFIG_CC_OPTIMIZE_FOR_PERFORMANCE_O3 Kconfig option that allows
 building the kernel with -O3 instead of the default -O2.
-Enable swing modulo scheduling (-fmodulo-sched, -fmodulo-sched-allow-regmoves,
--fivopts) for additional loop optimization by overlapping iterations
-of innermost loops.
+
+Enable swing modulo scheduling with the -fmodulo-sched,
+the -fmodulo-sched-allow-regmoves, and the -fivopts flags to improve
+innermost loop optimization by overlapping iterations.
+
 Enable LLVM pipeliner (-mllvm -enable-pipeliner) for additional
 loop pipelining on supported targets.
 
-Signed-off-by: damachine <damachin3@proton.me>
+Remove GCC's stack conservation flag and add the Zen/ClearLinux x86
+vectorization guard used with O3 builds.
 
+Includes compiler-tuning pieces from the Zen patchset and ClearLinux's
+x86 no-vectorization guard.
+
+Signed-off-by: Christian Kühn <damachin3@proton.me>
 ---
- Makefile     | 9 +++++++++
- init/Kconfig | 6 ++++++
- 2 files changed, 15 insertions(+)
+ Makefile          | 14 +++++++++-----
+ arch/x86/Makefile |  2 +-
+ init/Kconfig      |  6 ++++++
+ 3 files changed, 16 insertions(+), 6 deletions(-)
 
 diff --git a/Makefile b/Makefile
-index 36d0a32fb..510119afd 100644
+index 9e4052181..ca446ff83 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -893,11 +893,20 @@ KBUILD_CFLAGS	+= -fno-delete-null-pointer-checks
+@@ -924,16 +924,25 @@ KBUILD_CFLAGS	+= -fno-delete-null-pointer-checks
  ifdef CONFIG_CC_OPTIMIZE_FOR_PERFORMANCE
  KBUILD_CFLAGS += -O2
  KBUILD_RUSTFLAGS += -Copt-level=2
@@ -44,11 +54,41 @@ index 36d0a32fb..510119afd 100644
  # Always set `debug-assertions` and `overflow-checks` because their default
  # depends on `opt-level` and `debug-assertions`, respectively.
  KBUILD_RUSTFLAGS += -Cdebug-assertions=$(if $(CONFIG_RUST_DEBUG_ASSERTIONS),y,n)
+ KBUILD_RUSTFLAGS += -Coverflow-checks=$(if $(CONFIG_RUST_OVERFLOW_CHECKS),y,n)
+ 
+ # Tell gcc to never replace conditional load with a non-conditional one
+ ifdef CONFIG_CC_IS_GCC
+ # gcc-10 renamed --param=allow-store-data-races=0 to
+@@ -1136,11 +1161,6 @@ KBUILD_CFLAGS	+= -fno-strict-overflow
+ # Make sure -fstack-check isn't enabled (like gentoo apparently did)
+ KBUILD_CFLAGS  += -fno-stack-check
+ 
+-# conserve stack if available
+-ifdef CONFIG_CC_IS_GCC
+-KBUILD_CFLAGS   += -fconserve-stack
+-endif
+-
+ # Ensure compilers do not transform certain loops into calls to wcslen()
+ KBUILD_CFLAGS += -fno-builtin-wcslen
+ 
+diff --git a/arch/x86/Makefile b/arch/x86/Makefile
+index 1d526a5d2..ccceed491 100644
+--- a/arch/x86/Makefile
++++ b/arch/x86/Makefile
+@@ -73,7 +73,7 @@ export BITS
+ #
+ #    https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53383
+ #
+-KBUILD_CFLAGS += -mno-sse -mno-mmx -mno-sse2 -mno-3dnow -mno-avx -mno-sse4a
++KBUILD_CFLAGS += -mno-sse -mno-mmx -mno-sse2 -mno-3dnow -mno-avx -mno-sse4a -mno-avx2 -fno-tree-vectorize
+ KBUILD_RUSTFLAGS += --target=$(objtree)/scripts/target.json
+ KBUILD_RUSTFLAGS += -Ctarget-feature=-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-avx,-avx2
+ 
 diff --git a/init/Kconfig b/init/Kconfig
-index 7484cd703..a9975a9bd 100644
+index 2937c4d30..854c60996 100644
 --- a/init/Kconfig
 +++ b/init/Kconfig
-@@ -1582,6 +1582,12 @@ config CC_OPTIMIZE_FOR_PERFORMANCE
+@@ -1602,6 +1610,12 @@ config CC_OPTIMIZE_FOR_PERFORMANCE
  	  with the "-O2" compiler flag for best performance and most
  	  helpful compile-time warnings.
  
@@ -62,4 +102,4 @@ index 7484cd703..a9975a9bd 100644
  	bool "Optimize for size (-Os)"
  	help
 -- 
-2.53.0
+2.55.0

--- a/linux-tkg-patches/7.1/patchwork/last-successful-check/0013-clang-polly.patch
+++ b/linux-tkg-patches/7.1/patchwork/last-successful-check/0013-clang-polly.patch
@@ -1,0 +1,2 @@
+_patch_branch_hash=71e5926efc30833a6fd756b9358529ac695fa688ae71cd74e31dd274ae1ecf05
+_patch_kernel_tag=v7.1.4

--- a/linux-tkg-patches/7.1/patchwork/last-successful-check/0013-optimize_harder_O3.patch
+++ b/linux-tkg-patches/7.1/patchwork/last-successful-check/0013-optimize_harder_O3.patch
@@ -1,2 +1,2 @@
-_patch_branch_hash=5d77e58c279d1daaa95feb0dd01b74cdd44d6ae4530c6f5ef787f8002bb2f5c6
-_patch_kernel_tag=v7.1.3
+_patch_branch_hash=aaaefaba4da74180a092fdef83f76036d875ef9fa117282fe17d92931a2c990d
+_patch_kernel_tag=v7.1.4

--- a/linux-tkg-patches/7.2/0003-glitched-base.patch
+++ b/linux-tkg-patches/7.2/0003-glitched-base.patch
@@ -1,7 +1,7 @@
-From 9e6a62b4c654fbcd34b7f9c551992b26311e0ec2 Mon Sep 17 00:00:00 2001
+From b7f5b0f2870b959da1eaafd97f109e4ccb9b33e4 Mon Sep 17 00:00:00 2001
 From: Tk-Glitch <ti3nou@gmail.com>
 Date: Wed, 4 Jul 2018 04:30:08 +0200
-Subject: [PATCH 01/16] glitched
+Subject: [PATCH 01/21] glitched
 
 ---
  init/Makefile | 2 +-
@@ -21,13 +21,13 @@ index d6f75d890..9fa3e5890 100644
  
  #
 -- 
-2.54.0
+2.55.0
 
 
-From aa04524475d01bf3cb21d7e01551ad7258e49f73 Mon Sep 17 00:00:00 2001
+From 9dbcd7c476ab62a3a595429915b86a875718ba74 Mon Sep 17 00:00:00 2001
 From: Alexandre Frade <admfrade@gmail.com>
 Date: Mon, 29 Jan 2018 16:59:22 +0000
-Subject: [PATCH 02/16] dcache: cache_pressure = 50 decreases the rate at which
+Subject: [PATCH 02/21] dcache: cache_pressure = 50 decreases the rate at which
  VFS caches are reclaimed
 
 Signed-off-by: Alexandre Frade <admfrade@gmail.com>
@@ -66,13 +66,13 @@ index e474c31d8..0e4aedd9a 100644
  #ifdef CONFIG_SYSCTL
  static int sysctl_sched_rr_timeslice = (MSEC_PER_SEC * RR_TIMESLICE) / HZ;
 -- 
-2.54.0
+2.55.0
 
 
-From 8d1297ab432629142a9e734809de7ddf2e526e9c Mon Sep 17 00:00:00 2001
+From 1285bd64c6541a71db701970410fdea70239ebc9 Mon Sep 17 00:00:00 2001
 From: Alexandre Frade <admfrade@gmail.com>
 Date: Mon, 29 Jan 2018 17:41:29 +0000
-Subject: [PATCH 03/16] scripts: disable the localversion "+" tag of a git repo
+Subject: [PATCH 03/21] scripts: disable the localversion "+" tag of a git repo
 
 Signed-off-by: Alexandre Frade <admfrade@gmail.com>
 ---
@@ -93,13 +93,13 @@ index 28169d7e1..5cb02894a 100755
  		fi
  
 -- 
-2.54.0
+2.55.0
 
 
-From b4435fca34daf0c7c1f53fb80880e0bb244c19f7 Mon Sep 17 00:00:00 2001
+From ba12ca276b98013455baed07b82a8f5c12bf595c Mon Sep 17 00:00:00 2001
 From: "Jan Alexander Steffens (heftig)" <jan.steffens@gmail.com>
 Date: Fri, 26 Oct 2018 11:22:33 +0100
-Subject: [PATCH 04/16] infiniband: Fix __read_overflow2 error with -O3
+Subject: [PATCH 04/21] infiniband: Fix __read_overflow2 error with -O3
  inlining
 
 ---
@@ -119,23 +119,23 @@ index e9fb7ad4c..70289ff19 100644
  	int ret;
  
 -- 
-2.54.0
+2.55.0
 
 
-From 041ddd565e48dad749f06c98dd9f383aca2f5d77 Mon Sep 17 00:00:00 2001
+From 4505c065ac3c88c03274ee050da9b1c20dbb2a41 Mon Sep 17 00:00:00 2001
 From: Etienne Juvigny <Ti3noU@gmail.com>
 Date: Mon, 3 Sep 2018 17:36:25 +0200
-Subject: [PATCH 05/16] Add Zenify option
+Subject: [PATCH 05/21] Add Zenify option
 
 ---
- init/Kconfig | 32 ++++++++++++++++++++++++++++++++
- 1 file changed, 32 insertions(+)
+ init/Kconfig | 39 +++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 39 insertions(+)
 
 diff --git a/init/Kconfig b/init/Kconfig
-index 5230d4879..ed980f50c 100644
+index 5230d4879..342544ea0 100644
 --- a/init/Kconfig
 +++ b/init/Kconfig
-@@ -215,6 +215,38 @@ config THREAD_INFO_IN_TASK
+@@ -215,6 +215,45 @@ config THREAD_INFO_IN_TASK
  
  menu "General setup"
  
@@ -149,11 +149,14 @@ index 5230d4879..ed980f50c 100644
 +
 +	    Mem dirty before bg writeback..:  10 %  ->  20 %
 +	    Mem dirty before sync writeback:  20 %  ->  50 %
++	    Watermark boost factor.........:   1.5  ->   0
++	    Swap-in readahead..............:   3    ->   0
 +
 +	  --- Block Layer ----------------------------------------
 +
 +	    Queue depth...............:      128    -> 512
-+	    Default MQ scheduler......: mq-deadline -> bfq
++	    Default scheduler for SQ..: mq-deadline -> bfq
++	    Default scheduler for MQ..:        none -> kyber
 +
 +	  --- CFS CPU Scheduler ----------------------------------
 +
@@ -171,17 +174,21 @@ index 5230d4879..ed980f50c 100644
 +	    Ondemand coarse upscaling limit:  80 %  ->  45 %
 +	    Ondemand fine upscaling limit..:  95 %  ->  45 %
 +
++	  --- Split/Bus lock detection --------------------------
++
++	    Split lock mitigation..........:   1    ->   0
++
  config BROKEN
  	bool
  	help
 -- 
-2.54.0
+2.55.0
 
 
-From 38ac5d7deb55a57494beb3a0826cc99949d160b6 Mon Sep 17 00:00:00 2001
+From 648c78d1642376858e3bc2d48b21e0931c145c40 Mon Sep 17 00:00:00 2001
 From: Steven Barrett <damentz@liquorix.net>
 Date: Sun, 16 Jan 2011 18:57:32 -0600
-Subject: [PATCH 06/16] ZEN: Allow TCP YeAH as default congestion control
+Subject: [PATCH 06/21] ZEN: Allow TCP YeAH as default congestion control
 
 4.4: In my tests YeAH dramatically slowed down transfers over a WLAN,
      reducing throughput from ~65Mbps (CUBIC) to ~7MBps (YeAH) over 10
@@ -215,13 +222,13 @@ index 301b47660..3a7101d9b 100644
  	default "veno" if DEFAULT_VENO
  	default "reno" if DEFAULT_RENO
 -- 
-2.54.0
+2.55.0
 
 
-From a3beba9f8f44d97e9fe33e22c141a97264896d4b Mon Sep 17 00:00:00 2001
+From 9c5bc26763a4613e883344221ee7bbf42c957573 Mon Sep 17 00:00:00 2001
 From: Steven Barrett <steven@liquorix.net>
 Date: Wed, 28 Nov 2018 19:01:27 -0600
-Subject: [PATCH 07/16] zen: Use [defer+madvise] as default khugepaged defrag
+Subject: [PATCH 07/21] zen: Use [defer+madvise] as default khugepaged defrag
  strategy
 
 For some reason, the default strategy to respond to THP fault fallbacks
@@ -265,13 +272,13 @@ index 2bccb0a53..adf0301b6 100644
  	(1<<TRANSPARENT_HUGEPAGE_USE_ZERO_PAGE_FLAG);
  
 -- 
-2.54.0
+2.55.0
 
 
-From a187a61a5092811c510c58133e8c7a8c47d76ab8 Mon Sep 17 00:00:00 2001
+From 4e9b5c5ecd03287bb880c4a2fbb5642655d84321 Mon Sep 17 00:00:00 2001
 From: Alexandre Frade <admfrade@gmail.com>
 Date: Wed, 24 Oct 2018 16:58:52 -0300
-Subject: [PATCH 08/16] net/sched: allow configuring cake qdisc as default
+Subject: [PATCH 08/21] net/sched: allow configuring cake qdisc as default
 
 Signed-off-by: Alexandre Frade <admfrade@gmail.com>
 ---
@@ -301,111 +308,388 @@ index 6ddff028b..2c0fe1858 100644
  endif
  
 -- 
-2.54.0
+2.55.0
 
 
-From 8ab2bcd66c18383804b5312b32347b43b185f9ff Mon Sep 17 00:00:00 2001
-From: Tk-Glitch <ti3nou@gmail.com>
-Date: Fri, 19 Apr 2019 12:33:38 +0200
-Subject: [PATCH 09/16] Set vm.max_map_count to 262144 by default
+From 70818e29888865b47c6dfcba4227e44c4c3fb1b1 Mon Sep 17 00:00:00 2001
+From: Steven Barrett <steven@liquorix.net>
+Date: Thu, 27 Apr 2023 14:43:57 -0500
+Subject: [PATCH 09/21] ZEN: Set default max map count to (INT_MAX - 5)
 
-The value is still pretty low, and AMD64-ABI and ELF extended numbering
-supports that, so we should be fine on modern x86 systems.
+Per [Fedora][1], they intend to change the default max map count for
+their distribution to improve OOTB compatibility with games played
+through Steam/Proton.  The value they picked comes from the Steam Deck,
+which defaults to INT_MAX - MAPCOUNT_ELF_CORE_MARGIN.
 
-This fixes crashes in some applications using more than 65535 vmas (also
-affects some windows games running in wine, such as Star Citizen).
----
- include/linux/mm.h | 3 +--
- 1 file changed, 1 insertion(+), 2 deletions(-)
+Since most ZEN and Liquorix users probably play games, follow Valve's
+lead and raise this value to their default.
 
-diff --git a/include/linux/mm.h b/include/linux/mm.h
-index 485df9c2d..9d87743fb 100644
---- a/include/linux/mm.h
-+++ b/include/linux/mm.h
-@@ -204,8 +204,7 @@ static inline void __mm_zero_struct_page(struct page *page)
-  * not a hard limit any more. Although some userspace tools can be surprised by
-  * that.
-  */
--#define MAPCOUNT_ELF_CORE_MARGIN	(5)
--#define DEFAULT_MAX_MAP_COUNT	(USHRT_MAX - MAPCOUNT_ELF_CORE_MARGIN)
-+#define DEFAULT_MAX_MAP_COUNT	(262144)
- 
- extern unsigned long sysctl_user_reserve_kbytes;
- extern unsigned long sysctl_admin_reserve_kbytes;
--- 
-2.54.0
-
-
-From 3a88037c9265a456cca7eb0f52b32ae005561223 Mon Sep 17 00:00:00 2001
-From: Tk-Glitch <ti3nou@gmail.com>
-Date: Mon, 27 Jul 2020 00:19:18 +0200
-Subject: [PATCH 10/16] mm: bump DEFAULT_MAX_MAP_COUNT
-
-Some games such as Detroit: Become Human tend to be very crash prone with
-lower values.
+[1]: https://fedoraproject.org/wiki/Changes/IncreaseVmMaxMapCount
 ---
  include/linux/mm.h | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/include/linux/mm.h b/include/linux/mm.h
-index 9d87743fb..0bddf655d 100644
+index 485df9c2d..496c67117 100644
 --- a/include/linux/mm.h
 +++ b/include/linux/mm.h
-@@ -204,7 +204,7 @@ static inline void __mm_zero_struct_page(struct page *page)
-  * not a hard limit any more. Although some userspace tools can be surprised by
+@@ -205,7 +205,7 @@ static inline void __mm_zero_struct_page(struct page *page)
   * that.
   */
--#define DEFAULT_MAX_MAP_COUNT	(262144)
-+#define DEFAULT_MAX_MAP_COUNT	(16777216)
+ #define MAPCOUNT_ELF_CORE_MARGIN	(5)
+-#define DEFAULT_MAX_MAP_COUNT	(USHRT_MAX - MAPCOUNT_ELF_CORE_MARGIN)
++#define DEFAULT_MAX_MAP_COUNT	(INT_MAX - MAPCOUNT_ELF_CORE_MARGIN)
  
  extern unsigned long sysctl_user_reserve_kbytes;
  extern unsigned long sysctl_admin_reserve_kbytes;
 -- 
-2.54.0
+2.55.0
 
 
-From a6c101b750e8fccf932a1397e14acccc539c72e5 Mon Sep 17 00:00:00 2001
+From c018acc38489cc7cbb86dfc51ada4b6c80b6590c Mon Sep 17 00:00:00 2001
+From: Sultan Alsawaf <sultan@kerneltoast.com>
+Date: Sun, 19 Apr 2020 19:59:18 -0700
+Subject: [PATCH 10/21] ZEN: mm: Stop kswapd early when nothing's waiting for
+ it to free pages
+
+Contains:
+  - mm: Stop kswapd early when nothing's waiting for it to free pages
+
+    Keeping kswapd running when all the failed allocations that invoked it
+    are satisfied incurs a high overhead due to unnecessary page eviction
+    and writeback, as well as spurious VM pressure events to various
+    registered shrinkers. When kswapd doesn't need to work to make an
+    allocation succeed anymore, stop it prematurely to save resources.
+
+    Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
+
+  - mm: Don't stop kswapd on a per-node basis when there are no waiters
+
+    The page allocator wakes all kswapds in an allocation context's allowed
+    nodemask in the slow path, so it doesn't make sense to have the kswapd-
+    waiter count per each NUMA node. Instead, it should be a global counter
+    to stop all kswapds when there are no failed allocation requests.
+
+    Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
+
+  - mm: Increment kswapd_waiters for throttled direct reclaimers
+
+    Throttled direct reclaimers will wake up kswapd and wait for kswapd to
+    satisfy their page allocation request, even when the failed allocation
+    lacks the __GFP_KSWAPD_RECLAIM flag in its gfp mask. As a result, kswapd
+    may think that there are no waiters and thus exit prematurely, causing
+    throttled direct reclaimers lacking __GFP_KSWAPD_RECLAIM to stall on
+    waiting for kswapd to wake them up. Incrementing the kswapd_waiters
+    counter when such direct reclaimers become throttled fixes the problem.
+
+    Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
+---
+ mm/internal.h   |  1 +
+ mm/page_alloc.c | 17 ++++++++++++++---
+ mm/vmscan.c     | 19 +++++++++++++------
+ 3 files changed, 28 insertions(+), 9 deletions(-)
+
+diff --git a/mm/internal.h b/mm/internal.h
+index 181e79f1d..4177b3051 100644
+--- a/mm/internal.h
++++ b/mm/internal.h
+@@ -911,6 +911,7 @@ void post_alloc_hook(struct page *page, unsigned int order, gfp_t gfp_flags);
+ extern bool free_pages_prepare(struct page *page, unsigned int order);
+ 
+ extern int user_min_free_kbytes;
++extern atomic_long_t kswapd_waiters;
+ 
+ struct page *__alloc_frozen_pages_noprof(gfp_t, unsigned int order, int nid,
+ 		nodemask_t *);
+diff --git a/mm/page_alloc.c b/mm/page_alloc.c
+index ee902a468..742c0117d 100644
+--- a/mm/page_alloc.c
++++ b/mm/page_alloc.c
+@@ -93,6 +93,8 @@ typedef int __bitwise fpi_t;
+ /* free_pages_prepare() has already been called for page(s) being freed. */
+ #define FPI_PREPARED		((__force fpi_t)BIT(3))
+ 
++atomic_long_t kswapd_waiters = ATOMIC_LONG_INIT(0);
++
+ /* prevent >1 _updater_ of zone percpu pageset ->high and ->batch fields */
+ static DEFINE_MUTEX(pcp_batch_high_lock);
+ #define MIN_PERCPU_PAGELIST_HIGH_FRACTION (8)
+@@ -4741,6 +4743,7 @@ __alloc_pages_slowpath(gfp_t gfp_mask, unsigned int order,
+ 	int reserve_flags;
+ 	bool compact_first = false;
+ 	bool can_retry_reserves = true;
++	bool woke_kswapd = false;
+ 	unsigned long alloc_start_time = jiffies;
+ 
+ 	if (unlikely(nofail)) {
+@@ -4811,8 +4814,13 @@ __alloc_pages_slowpath(gfp_t gfp_mask, unsigned int order,
+ 
+ retry:
+ 	/* Ensure kswapd doesn't accidentally go to sleep as long as we loop */
+-	if (alloc_flags & ALLOC_KSWAPD)
++	if (alloc_flags & ALLOC_KSWAPD) {
++		if (!woke_kswapd) {
++			atomic_long_inc(&kswapd_waiters);
++			woke_kswapd = true;
++		}
+ 		wake_all_kswapds(order, gfp_mask, ac);
++	}
+ 
+ 	/*
+ 	 * The adjusted alloc_flags might result in immediate success, so try
+@@ -5017,9 +5025,12 @@ __alloc_pages_slowpath(gfp_t gfp_mask, unsigned int order,
+ 		goto retry;
+ 	}
+ fail:
+-	warn_alloc(gfp_mask, ac->nodemask,
+-			"page allocation failure: order:%u", order);
+ got_pg:
++	if (woke_kswapd)
++		atomic_long_dec(&kswapd_waiters);
++	if (!page)
++		warn_alloc(gfp_mask, ac->nodemask,
++				"page allocation failure: order:%u", order);
+ 	return page;
+ }
+ 
+diff --git a/mm/vmscan.c b/mm/vmscan.c
+index 35c3bb15a..ef48d3472 100644
+--- a/mm/vmscan.c
++++ b/mm/vmscan.c
+@@ -6548,7 +6548,7 @@ static unsigned long do_try_to_free_pages(struct zonelist *zonelist,
+ 	return 0;
+ }
+ 
+-static bool allow_direct_reclaim(pg_data_t *pgdat)
++static bool allow_direct_reclaim(pg_data_t *pgdat, bool using_kswapd)
+ {
+ 	struct zone *zone;
+ 	unsigned long pfmemalloc_reserve = 0;
+@@ -6573,6 +6573,10 @@ static bool allow_direct_reclaim(pg_data_t *pgdat)
+ 
+ 	wmark_ok = free_pages > pfmemalloc_reserve / 2;
+ 
++	/* The throttled direct reclaimer is now a kswapd waiter */
++	if (unlikely(!using_kswapd && !wmark_ok))
++		atomic_long_inc(&kswapd_waiters);
++
+ 	/* kswapd must be awake if processes are being throttled */
+ 	if (!wmark_ok && waitqueue_active(&pgdat->kswapd_wait)) {
+ 		if (READ_ONCE(pgdat->kswapd_highest_zoneidx) > ZONE_NORMAL)
+@@ -6638,7 +6642,7 @@ static bool throttle_direct_reclaim(gfp_t gfp_mask, struct zonelist *zonelist,
+ 
+ 		/* Throttle based on the first usable node */
+ 		pgdat = zone->zone_pgdat;
+-		if (allow_direct_reclaim(pgdat))
++		if (allow_direct_reclaim(pgdat, gfp_mask & __GFP_KSWAPD_RECLAIM))
+ 			goto out;
+ 		break;
+ 	}
+@@ -6660,11 +6664,14 @@ static bool throttle_direct_reclaim(gfp_t gfp_mask, struct zonelist *zonelist,
+ 	 */
+ 	if (!(gfp_mask & __GFP_FS))
+ 		wait_event_interruptible_timeout(pgdat->pfmemalloc_wait,
+-			allow_direct_reclaim(pgdat), HZ);
++			allow_direct_reclaim(pgdat, true), HZ);
+ 	else
+ 		/* Throttle until kswapd wakes the process */
+ 		wait_event_killable(zone->zone_pgdat->pfmemalloc_wait,
+-			allow_direct_reclaim(pgdat));
++			allow_direct_reclaim(pgdat, true));
++
++	if (unlikely(!(gfp_mask & __GFP_KSWAPD_RECLAIM)))
++		atomic_long_dec(&kswapd_waiters);
+ 
+ 	if (fatal_signal_pending(current))
+ 		return true;
+@@ -7192,14 +7199,14 @@ static int balance_pgdat(pg_data_t *pgdat, int order, int highest_zoneidx)
+ 		 * able to safely make forward progress. Wake them
+ 		 */
+ 		if (waitqueue_active(&pgdat->pfmemalloc_wait) &&
+-				allow_direct_reclaim(pgdat))
++				allow_direct_reclaim(pgdat, true))
+ 			wake_up_all(&pgdat->pfmemalloc_wait);
+ 
+ 		/* Check if kswapd should be suspending */
+ 		__fs_reclaim_release(_THIS_IP_);
+ 		ret = kthread_freezable_should_stop(&was_frozen);
+ 		__fs_reclaim_acquire(_THIS_IP_);
+-		if (was_frozen || ret)
++		if (was_frozen || ret || !atomic_long_read(&kswapd_waiters))
+ 			break;
+ 
+ 		/*
+-- 
+2.55.0
+
+
+From 16b4c697b28a17dc7db6706aa0ba8c5914a5cff4 Mon Sep 17 00:00:00 2001
+From: Sultan Alsawaf <sultan@kerneltoast.com>
+Date: Sat, 28 Mar 2020 13:06:28 -0700
+Subject: [PATCH 11/21] ZEN: INTERACTIVE: mm: Disable watermark boosting by
+ default
+
+What watermark boosting does is preemptively fire up kswapd to free
+memory when there hasn't been an allocation failure. It does this by
+increasing kswapd's high watermark goal and then firing up kswapd. The
+reason why this causes freezes is because, with the increased high
+watermark goal, kswapd will steal memory from processes that need it in
+order to make forward progress. These processes will, in turn, try to
+allocate memory again, which will cause kswapd to steal necessary pages
+from those processes again, in a positive feedback loop known as page
+thrashing. When page thrashing occurs, your system is essentially
+livelocked until the necessary forward progress can be made to stop
+processes from trying to continuously allocate memory and trigger
+kswapd to steal it back.
+
+This problem already occurs with kswapd *without* watermark boosting,
+but it's usually only encountered on machines with a small amount of
+memory and/or a slow CPU. Watermark boosting just makes the existing
+problem worse enough to notice on higher spec'd machines.
+
+Disable watermark boosting by default since it's a total dumpster fire.
+I can't imagine why anyone would want to explicitly enable it, but the
+option is there in case someone does.
+
+tkg: Config switch changed to our local "ZENIFY" toggle
+
+Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
+---
+ mm/page_alloc.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/mm/page_alloc.c b/mm/page_alloc.c
+index 742c0117d..32ee35203 100644
+--- a/mm/page_alloc.c
++++ b/mm/page_alloc.c
+@@ -272,7 +272,11 @@ const char * const migratetype_names[MIGRATE_TYPES] = {
+ 
+ int min_free_kbytes = 1024;
+ int user_min_free_kbytes = -1;
++#ifdef CONFIG_ZENIFY
++static int watermark_boost_factor __read_mostly;
++#else
+ static int watermark_boost_factor __read_mostly = 15000;
++#endif
+ static int watermark_scale_factor = 10;
+ int defrag_mode;
+ 
+-- 
+2.55.0
+
+
+From 9417d8fb748998999cdb75ab9f2537baff294f3d Mon Sep 17 00:00:00 2001
+From: Steven Barrett <steven@liquorix.net>
+Date: Mon, 5 Sep 2022 11:35:20 -0500
+Subject: [PATCH 12/21] ZEN: INTERACTIVE: mm/swap: Disable swap-in readahead
+
+Per an [issue][1] on the chromium project, swap-in readahead causes more
+jank than not.  This might be caused by poor optimization on the
+swapping code, or the fact under memory pressure, we're pulling in pages
+we don't need, causing more swapping.
+
+Either way, this is mainline/upstream to Chromium, and ChromeOS
+developers care a lot about system responsiveness. Lets implement the
+same change so Zen Kernel users benefit.
+
+[1]: https://bugs.chromium.org/p/chromium/issues/detail?id=263561
+
+tkg: Config switch changed to our local "ZENIFY" toggle
+---
+ mm/swap.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/mm/swap.c b/mm/swap.c
+index 588f50d8f..64bbf7258 100644
+--- a/mm/swap.c
++++ b/mm/swap.c
+@@ -1189,6 +1189,10 @@ static const struct ctl_table swap_sysctl_table[] = {
+  */
+ void __init swap_setup(void)
+ {
++#ifdef CONFIG_ZENIFY
++	/* Only swap-in pages requested, avoid readahead */
++	page_cluster = 0;
++#else
+ 	unsigned long megs = PAGES_TO_MB(totalram_pages());
+ 
+ 	/* Use a smaller cluster for small-memory machines */
+@@ -1200,6 +1204,7 @@ void __init swap_setup(void)
+ 	 * Right now other parts of the system means that we
+ 	 * _really_ don't want to cluster much more
+ 	 */
++#endif
+ 
+ 	register_sysctl_init("vm", swap_sysctl_table);
+ }
+-- 
+2.55.0
+
+
+From b0eede7eabfad22457bb167cddfd6298450e1aad Mon Sep 17 00:00:00 2001
 From: Alexandre Frade <admfrade@gmail.com>
 Date: Mon, 25 Nov 2019 15:13:06 -0300
-Subject: [PATCH 11/16] elevator: set default scheduler to bfq for blk-mq
+Subject: [PATCH 13/21] elevator: set interactive default schedulers for blk-mq
 
 Signed-off-by: Alexandre Frade <admfrade@gmail.com>
 ---
- block/elevator.c | 6 +++---
- 1 file changed, 3 insertions(+), 3 deletions(-)
+ block/elevator.c | 23 ++++++++++++++++-------
+ 1 file changed, 16 insertions(+), 7 deletions(-)
 
 diff --git a/block/elevator.c b/block/elevator.c
-index 3bcd37c2a..0beeb5b59 100644
+index 3bcd37c2a..c22bcaa5e 100644
 --- a/block/elevator.c
 +++ b/block/elevator.c
-@@ -729,7 +729,7 @@ void elv_update_nr_hw_queues(struct request_queue *q,
+@@ -729,7 +729,11 @@ void elv_update_nr_hw_queues(struct request_queue *q,
  void elevator_set_default(struct request_queue *q)
  {
  	struct elv_change_ctx ctx = {
--		.name = "mq-deadline",
++#if defined(CONFIG_ZENIFY) && defined(CONFIG_IOSCHED_BFQ)
 +		.name = "bfq",
++#else
+ 		.name = "mq-deadline",
++#endif
  		.no_uevent = true,
  	};
  	int err;
-@@ -741,8 +741,8 @@ void elevator_set_default(struct request_queue *q)
- 		return;
- 
- 	/*
--	 * For single queue devices, default to using mq-deadline. If we
--	 * have multiple queues or mq-deadline is not available, default
-+	 * For single queue devices, default to using bfq. If we
-+	 * have multiple queues or bfq is not available, default
+@@ -745,17 +749,22 @@ void elevator_set_default(struct request_queue *q)
+ 	 * have multiple queues or mq-deadline is not available, default
  	 * to "none".
  	 */
++	if (q->nr_hw_queues != 1 && !blk_mq_is_shared_tags(q->tag_set->flags))
++#if defined(CONFIG_ZENIFY) && defined(CONFIG_MQ_IOSCHED_KYBER)
++		ctx.name = "kyber";
++#else
++		return;
++#endif
++
  	ctx.type = elevator_find_get(ctx.name);
+ 	if (!ctx.type)
+ 		return;
+ 
+-	if ((q->nr_hw_queues == 1 ||
+-			blk_mq_is_shared_tags(q->tag_set->flags))) {
+-		err = elevator_change(q, &ctx);
+-		if (err < 0)
+-			pr_warn("\"%s\" elevator initialization, failed %d, falling back to \"none\"\n",
+-					ctx.name, err);
+-	}
++	err = elevator_change(q, &ctx);
++	if (err < 0)
++		pr_warn("\"%s\" elevator initialization, failed %d, falling back to \"none\"\n",
++				ctx.name, err);
++
+ 	elevator_put(ctx.type);
+ }
+ 
 -- 
-2.54.0
+2.55.0
 
 
-From f7727cf9f5accd2211aa504191076d8943704340 Mon Sep 17 00:00:00 2001
+From 5643e68e7d93588f93a8a7a1d5d0a2b9d723d3db Mon Sep 17 00:00:00 2001
 From: Alexandre Frade <kernel@xanmod.org>
 Date: Mon, 3 Aug 2020 17:05:04 +0000
-Subject: [PATCH 12/16] mm: set 2 megabytes for address_space-level file
+Subject: [PATCH 14/21] mm: set 2 megabytes for address_space-level file
  read-ahead pages size
 
 Signed-off-by: Alexandre Frade <kernel@xanmod.org>
@@ -414,7 +698,7 @@ Signed-off-by: Alexandre Frade <kernel@xanmod.org>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/include/linux/pagemap.h b/include/linux/pagemap.h
-index 2c3718d59..170c0fc15 100644
+index 2c3718d59..42dba9e2d 100644
 --- a/include/linux/pagemap.h
 +++ b/include/linux/pagemap.h
 @@ -1363,7 +1363,7 @@ struct readahead_control {
@@ -422,18 +706,60 @@ index 2c3718d59..170c0fc15 100644
  	}
  
 -#define VM_READAHEAD_PAGES	(SZ_128K / PAGE_SIZE)
-+#define VM_READAHEAD_PAGES	(SZ_2M / PAGE_SIZE)
++#define VM_READAHEAD_PAGES	(SZ_256K / PAGE_SIZE)
  
  void page_cache_ra_unbounded(struct readahead_control *,
  		unsigned long nr_to_read, unsigned long lookahead_count);
 -- 
-2.54.0
+2.55.0
 
 
-From 5e30930be00972b3f06d41286908f6fe0763b3db Mon Sep 17 00:00:00 2001
+From 086af7e9680a857ee5590a266154296ff7ca6364 Mon Sep 17 00:00:00 2001
+From: Steven Barrett <steven@liquorix.net>
+Date: Mon, 11 Jul 2022 19:10:30 -0500
+Subject: [PATCH 15/21] ZEN: cpufreq: Remove schedutil dependency on Intel/AMD
+ P-State drivers
+
+Although both P-State drivers depend on schedutil in Kconfig, both code
+bases do not use any schedutil code.  This arbitrarily enables schedutil
+when unwanted in some configurations.
+---
+ drivers/cpufreq/Kconfig.x86 | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/drivers/cpufreq/Kconfig.x86 b/drivers/cpufreq/Kconfig.x86
+index d6190b8dd..c73f75295 100644
+--- a/drivers/cpufreq/Kconfig.x86
++++ b/drivers/cpufreq/Kconfig.x86
+@@ -8,7 +8,6 @@ config X86_INTEL_PSTATE
+ 	select ACPI_PROCESSOR if ACPI
+ 	select ACPI_CPPC_LIB if X86_64 && ACPI && SCHED_MC_PRIO
+ 	select CPU_FREQ_GOV_PERFORMANCE
+-	select CPU_FREQ_GOV_SCHEDUTIL if SMP
+ 	help
+ 	  This driver provides a P state for Intel core processors.
+ 	  The driver implements an internal governor and will become
+@@ -38,7 +37,6 @@ config X86_AMD_PSTATE
+ 	depends on ACPI
+ 	select ACPI_PROCESSOR
+ 	select ACPI_CPPC_LIB if X86_64
+-	select CPU_FREQ_GOV_SCHEDUTIL if SMP
+ 	select ACPI_PLATFORM_PROFILE
+ 	select POWER_SUPPLY
+ 	help
+@@ -326,4 +324,3 @@ config CPUFREQ_ARCH_CUR_FREQ
+ 	  cpuinfo_avg_freq attribute, by enabling this option,
+ 	  scaling_cur_freq maintains the provision of a counter based frequency,
+ 	  for compatibility reasons.
+-
+-- 
+2.55.0
+
+
+From 9dbda250094fc1aed032aa7fd7d956da2b317151 Mon Sep 17 00:00:00 2001
 From: Steven Barrett <steven@liquorix.net>
 Date: Wed, 15 Jan 2020 20:43:56 -0600
-Subject: [PATCH 13/16] ZEN: intel-pstate: Implement "enable" parameter
+Subject: [PATCH 16/21] ZEN: intel-pstate: Implement "enable" parameter
 
 If intel-pstate is compiled into the kernel, it will preempt the loading
 of acpi-cpufreq so you can take advantage of hardware p-states without
@@ -475,26 +801,26 @@ index b5493a7f8..d0b3c6c92 100644
                            Use intel_pstate driver to bypass the scaling
                            governors layer of cpufreq and provides it own
 diff --git a/drivers/cpufreq/intel_pstate.c b/drivers/cpufreq/intel_pstate.c
-index 5a0eeb84d..58ea30938 100644
+index 5a0eeb84d..2e08fc04d 100644
 --- a/drivers/cpufreq/intel_pstate.c
 +++ b/drivers/cpufreq/intel_pstate.c
 @@ -3922,6 +3922,8 @@ static int __init intel_pstate_setup(char *str)
  
  	if (!strcmp(str, "disable"))
  		no_load = 1;
-+	else if (!strcmp(str, "enable"))
++	if (!strcmp(str, "enable"))
 +		no_load = 0;
  	else if (!strcmp(str, "active"))
  		default_driver = &intel_pstate;
  	else if (!strcmp(str, "passive"))
 -- 
-2.54.0
+2.55.0
 
 
-From b2c52963fa2ed3a3666371eb96c3113cb41e387c Mon Sep 17 00:00:00 2001
+From 927c738a1613f48c13bdfe85f66651dff3ccead1 Mon Sep 17 00:00:00 2001
 From: Kenny Levinsen <kl@kl.wtf>
 Date: Sun, 27 Dec 2020 14:43:13 +0000
-Subject: [PATCH 14/16] ZEN: Input: evdev - use call_rcu when detaching client
+Subject: [PATCH 17/21] ZEN: Input: evdev - use call_rcu when detaching client
 
 Significant time was spent on synchronize_rcu in evdev_detach_client
 when applications closed evdev devices. Switching VT away from a
@@ -599,13 +925,13 @@ index c7325226c..4f18a50ea 100644
  }
  
 -- 
-2.54.0
+2.55.0
 
 
-From a2a0e1e0b7c9a072543351e1b69f1d4075e94056 Mon Sep 17 00:00:00 2001
+From 86b6ba6e5de641095a9fca1eb38465d0fe070747 Mon Sep 17 00:00:00 2001
 From: Etienne JUVIGNY <ti3nou@gmail.com>
 Date: Mon, 6 Mar 2023 13:54:09 +0100
-Subject: [PATCH 15/16] Don't add -dirty versioning on unclean trees
+Subject: [PATCH 18/21] Don't add -dirty versioning on unclean trees
 
 ---
  scripts/setlocalversion | 12 ++++++------
@@ -635,13 +961,13 @@ index 5cb02894a..6fe69fcc9 100755
  
  collect_files()
 -- 
-2.54.0
+2.55.0
 
 
-From 1690ee1a3bc40f27023237448561c33ee15cb334 Mon Sep 17 00:00:00 2001
+From 2f45233247fa1b0c7f3f342d00567bf46478d579 Mon Sep 17 00:00:00 2001
 From: Steven Barrett <steven@liquorix.net>
 Date: Sat, 21 May 2022 15:15:09 -0500
-Subject: [PATCH 16/16] ZEN: INTERACTIVE: dm-crypt: Disable workqueues for
+Subject: [PATCH 19/21] ZEN: INTERACTIVE: dm-crypt: Disable workqueues for
  crypto ops
 
 Queueing in dm-crypt for crypto operations reduces performance on modern
@@ -677,5 +1003,461 @@ index 608b617fb..7f9a6adb6 100644
  	if (ret < 0)
  		goto bad;
 -- 
-2.54.0
+2.55.0
+
+
+From a3c573eaf10bae8e1959873068aac0d497384e04 Mon Sep 17 00:00:00 2001
+From: Steven Barrett <steven@liquorix.net>
+Date: Sat, 14 Feb 2026 08:59:02 -0600
+Subject: [PATCH 20/21] ZEN: INTERACTIVE: Disable split lock mitigation by
+ default
+
+Split lock detection and mitigation is useful on multi tenant systems
+where the software interacting with the kernel may not be in control of
+the system owner.  Rate limiting bad code is important to reduce the
+effect of split locks on other tenants.
+
+However, most Zen Kernel users are running this kernel for just
+themselves and are unlikely to have multiple interactive sessions at
+once.
+
+Turn off split lock mitigation, by default so software that would
+otherwise be rate limited works as intended.
+
+tkg: Config switch changed to our local "ZENIFY" toggle
+---
+ arch/x86/kernel/cpu/bus_lock.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/arch/x86/kernel/cpu/bus_lock.c b/arch/x86/kernel/cpu/bus_lock.c
+index bba28607a..60c76d0d9 100644
+--- a/arch/x86/kernel/cpu/bus_lock.c
++++ b/arch/x86/kernel/cpu/bus_lock.c
+@@ -47,7 +47,11 @@ static const struct {
+ 
+ static struct ratelimit_state bld_ratelimit;
+ 
++#ifdef CONFIG_ZENIFY
++static unsigned int sysctl_sld_mitigate;
++#else
+ static unsigned int sysctl_sld_mitigate = 1;
++#endif
+ static DEFINE_SEMAPHORE(buslock_sem, 1);
+ 
+ #ifdef CONFIG_PROC_SYSCTL
+-- 
+2.55.0
+
+
+From 500682ababc35f1bcf19765b053128063df56142 Mon Sep 17 00:00:00 2001
+From: Xie Yuanbin <qq570070308@gmail.com>
+Date: Sun, 23 Nov 2025 20:18:27 +0800
+Subject: [PATCH 21/21] ZEN: sched/core: Make finish_task_switch() and its
+ subfunctions always inline
+
+finish_task_switch() is a hot code path in context switching.
+When spectre_v2_user is enabled, kernel is likely to perform branch
+prediction hardening inside switch_mm_irqs_off(). finish_task_switch()
+is right after switch_mm_irqs_off(), so the performance here is
+greatly affected by function calls and branch jumps.
+
+Make finish_task_switch() always inline to optimize performance.
+
+After finish_task_switch() is changed as always inline, the number of
+calling points of subfunctions increases. According to the compiler
+optimization strategy, subfunctions that were originally inline may no
+longer be inline.
+
+Also make the subfunctions of finish_task_stwitch() always inline to
+prevent performance degradation.
+
+There is a improvement in the performace of finish_task_switch(). When
+spectre v2 is enabled, the improvement is significant.
+
+The following are testing results from intel i5-8300h@4Ghz (x86):
+Time spent on calling finish_task_switch(), the unit is tsc from x86:
+ | test scenario             | old   | new   | delta          |
+ | gcc 15.2                  | 13.94 | 12.40 | 1.54  (-11.1%) |
+ | gcc 15.2 + spectre_v2     | 24.78 | 13.70 | 11.08 (-44.7%) |
+ | clang 21.1.4              | 13.90 | 12.71 | 1.19  (- 8.6%) |
+ | clang 21.1.4 + spectre_v2 | 29.01 | 18.91 | 10.1  (-34.8%) |
+
+There is a minor improvement in the size of .text section in vmlinux,
+the unit is bytes:
+ | test scenario             | old      | new      | delta |
+ | gcc 15.2                  | 16208096 | 16208736 | 640   |
+ | clang 21.1.4              | 17943328 | 17944224 | 896   |
+
+No size changes were found on bzImage.
+
+Signed-off-by: Xie Yuanbin <qq570070308@gmail.com>
+Cc: Thomas Gleixner <tglx@linutronix.de>
+Cc: Rik van Riel <riel@surriel.com>
+Cc: Segher Boessenkool <segher@kernel.crashing.org>
+Cc: David Hildenbrand (Red Hat) <david@kernel.org>
+Cc: Peter Zijlstra <peterz@infradead.org>
+Cc: H. Peter Anvin (Intel) <hpa@zytor.com>
+Cc: Arnd Bergmann <arnd@arndb.de>
+---
+ arch/arm/include/asm/mmu_context.h      |  2 +-
+ arch/riscv/include/asm/sync_core.h      |  2 +-
+ arch/s390/include/asm/mmu_context.h     |  2 +-
+ arch/sparc/include/asm/mmu_context_64.h |  2 +-
+ arch/x86/include/asm/sync_core.h        |  2 +-
+ include/linux/perf_event.h              |  2 +-
+ include/linux/sched/mm.h                | 10 +++++-----
+ include/linux/tick.h                    |  4 ++--
+ include/linux/vtime.h                   | 12 ++++++------
+ kernel/sched/core.c                     | 14 +++++++-------
+ kernel/sched/sched.h                    | 20 ++++++++++----------
+ 11 files changed, 36 insertions(+), 36 deletions(-)
+
+diff --git a/arch/arm/include/asm/mmu_context.h b/arch/arm/include/asm/mmu_context.h
+index db2cb06aa..bebde469f 100644
+--- a/arch/arm/include/asm/mmu_context.h
++++ b/arch/arm/include/asm/mmu_context.h
+@@ -80,7 +80,7 @@ static inline void check_and_switch_context(struct mm_struct *mm,
+ #ifndef MODULE
+ #define finish_arch_post_lock_switch \
+ 	finish_arch_post_lock_switch
+-static inline void finish_arch_post_lock_switch(void)
++static __always_inline void finish_arch_post_lock_switch(void)
+ {
+ 	struct mm_struct *mm = current->mm;
+ 
+diff --git a/arch/riscv/include/asm/sync_core.h b/arch/riscv/include/asm/sync_core.h
+index 9153016da..2fe6b7fe6 100644
+--- a/arch/riscv/include/asm/sync_core.h
++++ b/arch/riscv/include/asm/sync_core.h
+@@ -6,7 +6,7 @@
+  * RISC-V implements return to user-space through an xRET instruction,
+  * which is not core serializing.
+  */
+-static inline void sync_core_before_usermode(void)
++static __always_inline void sync_core_before_usermode(void)
+ {
+ 	asm volatile ("fence.i" ::: "memory");
+ }
+diff --git a/arch/s390/include/asm/mmu_context.h b/arch/s390/include/asm/mmu_context.h
+index bd1ef5e2d..95d03be2c 100644
+--- a/arch/s390/include/asm/mmu_context.h
++++ b/arch/s390/include/asm/mmu_context.h
+@@ -93,7 +93,7 @@ static inline void switch_mm(struct mm_struct *prev, struct mm_struct *next,
+ }
+ 
+ #define finish_arch_post_lock_switch finish_arch_post_lock_switch
+-static inline void finish_arch_post_lock_switch(void)
++static __always_inline void finish_arch_post_lock_switch(void)
+ {
+ 	struct task_struct *tsk = current;
+ 	struct mm_struct *mm = tsk->mm;
+diff --git a/arch/sparc/include/asm/mmu_context_64.h b/arch/sparc/include/asm/mmu_context_64.h
+index 78bbacc14..d1967214e 100644
+--- a/arch/sparc/include/asm/mmu_context_64.h
++++ b/arch/sparc/include/asm/mmu_context_64.h
+@@ -160,7 +160,7 @@ static inline void arch_start_context_switch(struct task_struct *prev)
+ }
+ 
+ #define finish_arch_post_lock_switch	finish_arch_post_lock_switch
+-static inline void finish_arch_post_lock_switch(void)
++static __always_inline void finish_arch_post_lock_switch(void)
+ {
+ 	/* Restore the state of MCDPER register for the new process
+ 	 * just switched to.
+diff --git a/arch/x86/include/asm/sync_core.h b/arch/x86/include/asm/sync_core.h
+index 96bda4353..4b55fa353 100644
+--- a/arch/x86/include/asm/sync_core.h
++++ b/arch/x86/include/asm/sync_core.h
+@@ -93,7 +93,7 @@ static __always_inline void sync_core(void)
+  * to user-mode. x86 implements return to user-space through sysexit,
+  * sysrel, and sysretq, which are not core serializing.
+  */
+-static inline void sync_core_before_usermode(void)
++static __always_inline void sync_core_before_usermode(void)
+ {
+ 	/* With PTI, we unconditionally serialize before running user code. */
+ 	if (static_cpu_has(X86_FEATURE_PTI))
+diff --git a/include/linux/perf_event.h b/include/linux/perf_event.h
+index 48d851fbd..7c1dac8da 100644
+--- a/include/linux/perf_event.h
++++ b/include/linux/perf_event.h
+@@ -1632,7 +1632,7 @@ static inline void perf_event_task_migrate(struct task_struct *task)
+ 		task->sched_migrated = 1;
+ }
+ 
+-static inline void perf_event_task_sched_in(struct task_struct *prev,
++static __always_inline void perf_event_task_sched_in(struct task_struct *prev,
+ 					    struct task_struct *task)
+ {
+ 	if (static_branch_unlikely(&perf_sched_events))
+diff --git a/include/linux/sched/mm.h b/include/linux/sched/mm.h
+index 95d0040df..4a279ee2d 100644
+--- a/include/linux/sched/mm.h
++++ b/include/linux/sched/mm.h
+@@ -44,7 +44,7 @@ static inline void smp_mb__after_mmgrab(void)
+ 
+ extern void __mmdrop(struct mm_struct *mm);
+ 
+-static inline void mmdrop(struct mm_struct *mm)
++static __always_inline void mmdrop(struct mm_struct *mm)
+ {
+ 	/*
+ 	 * The implicit full barrier implied by atomic_dec_and_test() is
+@@ -71,14 +71,14 @@ static inline void __mmdrop_delayed(struct rcu_head *rhp)
+  * Invoked from finish_task_switch(). Delegates the heavy lifting on RT
+  * kernels via RCU.
+  */
+-static inline void mmdrop_sched(struct mm_struct *mm)
++static __always_inline void mmdrop_sched(struct mm_struct *mm)
+ {
+ 	/* Provides a full memory barrier. See mmdrop() */
+ 	if (atomic_dec_and_test(&mm->mm_count))
+ 		call_rcu(&mm->delayed_drop, __mmdrop_delayed);
+ }
+ #else
+-static inline void mmdrop_sched(struct mm_struct *mm)
++static __always_inline void mmdrop_sched(struct mm_struct *mm)
+ {
+ 	mmdrop(mm);
+ }
+@@ -104,7 +104,7 @@ static inline void mmdrop_lazy_tlb(struct mm_struct *mm)
+ 	}
+ }
+ 
+-static inline void mmdrop_lazy_tlb_sched(struct mm_struct *mm)
++static __always_inline void mmdrop_lazy_tlb_sched(struct mm_struct *mm)
+ {
+ 	if (IS_ENABLED(CONFIG_MMU_LAZY_TLB_REFCOUNT))
+ 		mmdrop_sched(mm);
+@@ -532,7 +532,7 @@ enum {
+ #include <asm/membarrier.h>
+ #endif
+ 
+-static inline void membarrier_mm_sync_core_before_usermode(struct mm_struct *mm)
++static __always_inline void membarrier_mm_sync_core_before_usermode(struct mm_struct *mm)
+ {
+ 	/*
+ 	 * The atomic_read() below prevents CSE. The following should
+diff --git a/include/linux/tick.h b/include/linux/tick.h
+index 1cf4651f0..2f91eccd2 100644
+--- a/include/linux/tick.h
++++ b/include/linux/tick.h
+@@ -173,7 +173,7 @@ extern cpumask_var_t tick_nohz_full_mask;
+ #ifdef CONFIG_NO_HZ_FULL
+ extern bool tick_nohz_full_running;
+ 
+-static inline bool tick_nohz_full_enabled(void)
++static __always_inline bool tick_nohz_full_enabled(void)
+ {
+ 	if (!context_tracking_enabled())
+ 		return false;
+@@ -297,7 +297,7 @@ static inline void __tick_nohz_task_switch(void) { }
+ static inline void tick_nohz_full_setup(cpumask_var_t cpumask) { }
+ #endif
+ 
+-static inline void tick_nohz_task_switch(void)
++static __always_inline void tick_nohz_task_switch(void)
+ {
+ 	if (tick_nohz_full_enabled())
+ 		__tick_nohz_task_switch();
+diff --git a/include/linux/vtime.h b/include/linux/vtime.h
+index 82825e775..28234dda2 100644
+--- a/include/linux/vtime.h
++++ b/include/linux/vtime.h
+@@ -26,12 +26,12 @@ static inline void vtime_guest_exit(struct task_struct *tsk) { }
+ static inline void vtime_init_idle(struct task_struct *tsk, int cpu) { }
+ #endif
+ 
+-static inline bool vtime_generic_enabled_cpu(int cpu)
++static __always_inline bool vtime_generic_enabled_cpu(int cpu)
+ {
+ 	return context_tracking_enabled_cpu(cpu);
+ }
+ 
+-static inline bool vtime_generic_enabled_this_cpu(void)
++static __always_inline bool vtime_generic_enabled_this_cpu(void)
+ {
+ 	return context_tracking_enabled_this_cpu();
+ }
+@@ -89,24 +89,24 @@ static __always_inline void vtime_account_guest_exit(void)
+  * For now vtime state is tied to context tracking. We might want to decouple
+  * those later if necessary.
+  */
+-static inline bool vtime_accounting_enabled(void)
++static __always_inline bool vtime_accounting_enabled(void)
+ {
+ 	return context_tracking_enabled();
+ }
+ 
+-static inline bool vtime_accounting_enabled_cpu(int cpu)
++static __always_inline bool vtime_accounting_enabled_cpu(int cpu)
+ {
+ 	return vtime_generic_enabled_cpu(cpu);
+ }
+ 
+-static inline bool vtime_accounting_enabled_this_cpu(void)
++static __always_inline bool vtime_accounting_enabled_this_cpu(void)
+ {
+ 	return vtime_generic_enabled_this_cpu();
+ }
+ 
+ extern void vtime_task_switch_generic(struct task_struct *prev);
+ 
+-static inline void vtime_task_switch(struct task_struct *prev)
++static __always_inline void vtime_task_switch(struct task_struct *prev)
+ {
+ 	if (vtime_accounting_enabled_this_cpu())
+ 		vtime_task_switch_generic(prev);
+diff --git a/kernel/sched/core.c b/kernel/sched/core.c
+index 96226707c..6014cc8fb 100644
+--- a/kernel/sched/core.c
++++ b/kernel/sched/core.c
+@@ -5074,7 +5074,7 @@ static inline void prepare_task(struct task_struct *next)
+ 	WRITE_ONCE(next->on_cpu, 1);
+ }
+ 
+-static inline void finish_task(struct task_struct *prev)
++static __always_inline void finish_task(struct task_struct *prev)
+ {
+ 	/*
+ 	 * This must be the very last reference to @prev from this CPU. After
+@@ -5118,7 +5118,7 @@ static void zap_balance_callbacks(struct rq *rq)
+ 	rq->balance_callback = found ? &balance_push_callback : NULL;
+ }
+ 
+-static void do_balance_callbacks(struct rq *rq, struct balance_callback *head)
++static __always_inline void do_balance_callbacks(struct rq *rq, struct balance_callback *head)
+ {
+ 	void (*func)(struct rq *rq);
+ 	struct balance_callback *next;
+@@ -5153,7 +5153,7 @@ struct balance_callback balance_push_callback = {
+ 	.func = balance_push,
+ };
+ 
+-static inline struct balance_callback *
++static __always_inline struct balance_callback *
+ __splice_balance_callbacks(struct rq *rq, bool split)
+ {
+ 	struct balance_callback *head = rq->balance_callback;
+@@ -5183,7 +5183,7 @@ struct balance_callback *splice_balance_callbacks(struct rq *rq)
+ 	return __splice_balance_callbacks(rq, true);
+ }
+ 
+-void __balance_callbacks(struct rq *rq, struct rq_flags *rf)
++__always_inline void __balance_callbacks(struct rq *rq, struct rq_flags *rf)
+ {
+ 	if (rf)
+ 		rq_unpin_lock(rq, rf);
+@@ -5227,7 +5227,7 @@ prepare_lock_switch(struct rq *rq, struct task_struct *next, struct rq_flags *rf
+ 	__acquire(__rq_lockp(this_rq()));
+ }
+ 
+-static inline void finish_lock_switch(struct rq *rq)
++static __always_inline void finish_lock_switch(struct rq *rq)
+ 	__releases(__rq_lockp(rq))
+ {
+ 	/*
+@@ -5261,7 +5261,7 @@ static inline void kmap_local_sched_out(void)
+ #endif
+ }
+ 
+-static inline void kmap_local_sched_in(void)
++static __always_inline void kmap_local_sched_in(void)
+ {
+ #ifdef CONFIG_KMAP_LOCAL
+ 	if (unlikely(current->kmap_ctrl.idx))
+@@ -5315,7 +5315,7 @@ prepare_task_switch(struct rq *rq, struct task_struct *prev,
+  * past. 'prev == current' is still correct but we need to recalculate this_rq
+  * because prev may have moved to another CPU.
+  */
+-static struct rq *finish_task_switch(struct task_struct *prev)
++static __always_inline struct rq *finish_task_switch(struct task_struct *prev)
+ 	__releases(__rq_lockp(this_rq()))
+ {
+ 	struct rq *rq = this_rq();
+diff --git a/kernel/sched/sched.h b/kernel/sched/sched.h
+index 56acf502b..b8e75cdc2 100644
+--- a/kernel/sched/sched.h
++++ b/kernel/sched/sched.h
+@@ -1457,12 +1457,12 @@ static inline struct cpumask *sched_group_span(struct sched_group *sg);
+ 
+ DECLARE_STATIC_KEY_FALSE(__sched_core_enabled);
+ 
+-static inline bool sched_core_enabled(struct rq *rq)
++static __always_inline bool sched_core_enabled(struct rq *rq)
+ {
+ 	return static_branch_unlikely(&__sched_core_enabled) && rq->core_enabled;
+ }
+ 
+-static inline bool sched_core_disabled(void)
++static __always_inline bool sched_core_disabled(void)
+ {
+ 	return !static_branch_unlikely(&__sched_core_enabled);
+ }
+@@ -1471,7 +1471,7 @@ static inline bool sched_core_disabled(void)
+  * Be careful with this function; not for general use. The return value isn't
+  * stable unless you actually hold a relevant rq->__lock.
+  */
+-static inline raw_spinlock_t *rq_lockp(struct rq *rq)
++static __always_inline raw_spinlock_t *rq_lockp(struct rq *rq)
+ {
+ 	if (sched_core_enabled(rq))
+ 		return &rq->core->__lock;
+@@ -1479,7 +1479,7 @@ static inline raw_spinlock_t *rq_lockp(struct rq *rq)
+ 	return &rq->__lock;
+ }
+ 
+-static inline raw_spinlock_t *__rq_lockp(struct rq *rq)
++static __always_inline raw_spinlock_t *__rq_lockp(struct rq *rq)
+ 	__returns_ctx_lock(rq_lockp(rq)) /* alias them */
+ {
+ 	if (rq->core_enabled)
+@@ -1582,12 +1582,12 @@ static inline bool sched_core_disabled(void)
+ 	return true;
+ }
+ 
+-static inline raw_spinlock_t *rq_lockp(struct rq *rq)
++static __always_inline raw_spinlock_t *rq_lockp(struct rq *rq)
+ {
+ 	return &rq->__lock;
+ }
+ 
+-static inline raw_spinlock_t *__rq_lockp(struct rq *rq)
++static __always_inline raw_spinlock_t *__rq_lockp(struct rq *rq)
+ 	__returns_ctx_lock(rq_lockp(rq)) /* alias them */
+ {
+ 	return &rq->__lock;
+@@ -1647,26 +1647,26 @@ extern void raw_spin_rq_lock_nested(struct rq *rq, int subclass)
+ extern bool raw_spin_rq_trylock(struct rq *rq)
+ 	__cond_acquires(true, __rq_lockp(rq));
+ 
+-static inline void raw_spin_rq_lock(struct rq *rq)
++static __always_inline void raw_spin_rq_lock(struct rq *rq)
+ 	__acquires(__rq_lockp(rq))
+ {
+ 	raw_spin_rq_lock_nested(rq, 0);
+ }
+ 
+-static inline void raw_spin_rq_unlock(struct rq *rq)
++static __always_inline void raw_spin_rq_unlock(struct rq *rq)
+ 	__releases(__rq_lockp(rq))
+ {
+ 	raw_spin_unlock(rq_lockp(rq));
+ }
+ 
+-static inline void raw_spin_rq_lock_irq(struct rq *rq)
++static __always_inline void raw_spin_rq_lock_irq(struct rq *rq)
+ 	__acquires(__rq_lockp(rq))
+ {
+ 	local_irq_disable();
+ 	raw_spin_rq_lock(rq);
+ }
+ 
+-static inline void raw_spin_rq_unlock_irq(struct rq *rq)
++static __always_inline void raw_spin_rq_unlock_irq(struct rq *rq)
+ 	__releases(__rq_lockp(rq))
+ {
+ 	raw_spin_rq_unlock(rq);
+-- 
+2.55.0
 

--- a/linux-tkg-patches/7.2/0013-clang-polly.patch
+++ b/linux-tkg-patches/7.2/0013-clang-polly.patch
@@ -1,0 +1,156 @@
+From 836c16fbbd981fcf4f6b39faad2e7e7be13d5434 Mon Sep 17 00:00:00 2001
+From: Peter Jung <admin@ptr1337.dev>
+Date: Thu, 12 Dec 2024 17:28:45 +0100
+Subject: [PATCH 1/3] kbuild: Add support for Clang's polyhedral loop
+ optimizer.
+
+Polly is able to optimize various loops throughout the kernel for cache
+locality. A mathematical representation of the program, based on
+polyhedra, is analysed to find opportunistic optimisations in memory
+access patterns which then leads to loop transformations.
+
+Polly is not built with LLVM by default, and requires LLVM to be compiled
+with the Polly "project". This can be done by adding Polly to
+-DLLVM_ENABLE_PROJECTS, for example:
+
+-DLLVM_ENABLE_PROJECTS="clang;libcxx;libcxxabi;polly"
+
+Preliminary benchmarking seems to show an improvement of around two
+percent across perf benchmarks:
+
+Benchmark                         | Control    | Polly
+--------------------------------------------------------
+bonnie++ -x 2 -s 4096 -r 0        | 12.610s    | 12.547s
+perf bench futex requeue          | 33.553s    | 33.094s
+perf bench futex wake             |  1.032s    |  1.021s
+perf bench futex wake-parallel    |  1.049s    |  1.025s
+perf bench futex requeue          |  1.037s    |  1.020s
+
+Furthermore, Polly does not produce a much larger image size netting it
+to be a "free" optimisation. A comparison of a bzImage for a kernel with
+and without Polly is shown below:
+
+bzImage        | stat --printf="%s\n"
+-------------------------------------
+Control        | 9333728
+Polly          | 9345792
+
+Compile times were one percent different at best, which is well within
+the range of noise. Therefore, I can say with certainty that Polly has
+a minimal effect on compile times, if none.
+
+Signed-off-by: Peter Jung <admin@ptr1337.dev>
+---
+ Makefile     | 16 ++++++++++++++++
+ init/Kconfig | 13 +++++++++++++
+ 2 files changed, 29 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index 64c594bd7..5f0cb6238 100644
+--- a/Makefile
++++ b/Makefile
+@@ -870,6 +870,22 @@ endif
+ KBUILD_RUSTFLAGS += -Cdebug-assertions=$(if $(CONFIG_RUST_DEBUG_ASSERTIONS),y,n)
+ KBUILD_RUSTFLAGS += -Coverflow-checks=$(if $(CONFIG_RUST_OVERFLOW_CHECKS),y,n)
+ 
++ifdef CONFIG_POLLY_CLANG
++KBUILD_CFLAGS	+= -mllvm -polly \
++		   -mllvm -polly-ast-use-context \
++		   -mllvm -polly-invariant-load-hoisting \
++		   -mllvm -polly-opt-fusion=max \
++		   -mllvm -polly-run-inliner \
++		   -mllvm -polly-vectorizer=stripmine
++# Polly may optimise loops with dead paths beyound what the linker
++# can understand. This may negate the effect of the linker's DCE
++# so we tell Polly to perfom proven DCE on the loops it optimises
++# in order to preserve the overall effect of the linker's DCE.
++ifdef CONFIG_LD_DEAD_CODE_DATA_ELIMINATION
++KBUILD_CFLAGS	+= -mllvm -polly-run-dce
++endif
++endif
++
+ # Tell gcc to never replace conditional load with a non-conditional one
+ ifdef CONFIG_CC_IS_GCC
+ # gcc-10 renamed --param=allow-store-data-races=0 to
+diff --git a/init/Kconfig b/init/Kconfig
+index a20e6efd3..66adb2fc9 100644
+--- a/init/Kconfig
++++ b/init/Kconfig
+@@ -251,6 +251,19 @@ config BUILD_SALT
+ 	  This is mostly useful for distributions which want to ensure the
+ 	  build is unique between builds. It's safe to leave the default.
+ 
++config POLLY_CLANG
++	bool "Use Clang Polly optimizations"
++	depends on CC_IS_CLANG && $(cc-option,-mllvm -polly -fplugin=LLVMPolly.so)
++	depends on !COMPILE_TEST
++	help
++	  This option enables Clang's polyhedral loop optimizer known as
++	  Polly. Polly is able to optimize various loops throughout the
++	  kernel for cache locality. This requires a Clang toolchain
++	  compiled with support for Polly. More information can be found
++	  from Polly's website:
++
++	    https://polly.llvm.org
++
+ config HAVE_KERNEL_GZIP
+ 	bool
+ 
+-- 
+2.47.1
+
+
+From 8b5347cd5e745e8d0a68b28e55b48c62e6c0c513 Mon Sep 17 00:00:00 2001
+From: Username404-59 <w.iron.zombie@gmail.com>
+Date: Thu, 12 Dec 2024 21:25:40 +0100
+Subject: [PATCH 2/3] kbuild: Update old polly option
+
+Signed-off-by: Username404-59 <w.iron.zombie@gmail.com>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 5f0cb6238..fa433f1d9 100644
+--- a/Makefile
++++ b/Makefile
+@@ -874,7 +874,7 @@ ifdef CONFIG_POLLY_CLANG
+ KBUILD_CFLAGS	+= -mllvm -polly \
+ 		   -mllvm -polly-ast-use-context \
+ 		   -mllvm -polly-invariant-load-hoisting \
+-		   -mllvm -polly-opt-fusion=max \
++		   -mllvm -polly-loopfusion-greedy \
+ 		   -mllvm -polly-run-inliner \
+ 		   -mllvm -polly-vectorizer=stripmine
+ # Polly may optimise loops with dead paths beyound what the linker
+-- 
+2.47.1
+
+
+From 562335afe34f24f9940d198d536e941e326a9716 Mon Sep 17 00:00:00 2001
+From: Username404-59 <w.iron.zombie@gmail.com>
+Date: Thu, 12 Dec 2024 21:41:01 +0100
+Subject: [PATCH 3/3] kbuild: load polly llvm plugin
+
+Signed-off-by: Username404-59 <w.iron.zombie@gmail.com>
+---
+ Makefile | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index fa433f1d9..e8737f5ea 100644
+--- a/Makefile
++++ b/Makefile
+@@ -871,7 +871,8 @@ KBUILD_RUSTFLAGS += -Cdebug-assertions=$(if $(CONFIG_RUST_DEBUG_ASSERTIONS),y,n)
+ KBUILD_RUSTFLAGS += -Coverflow-checks=$(if $(CONFIG_RUST_OVERFLOW_CHECKS),y,n)
+ 
+ ifdef CONFIG_POLLY_CLANG
+-KBUILD_CFLAGS	+= -mllvm -polly \
++KBUILD_CFLAGS	+= -fplugin=LLVMPolly.so \
++		   -mllvm -polly \
+ 		   -mllvm -polly-ast-use-context \
+ 		   -mllvm -polly-invariant-load-hoisting \
+ 		   -mllvm -polly-loopfusion-greedy \
+-- 
+2.47.1
+

--- a/linux-tkg-patches/7.2/0013-optimize_harder_O3.patch
+++ b/linux-tkg-patches/7.2/0013-optimize_harder_O3.patch
@@ -1,29 +1,39 @@
-From f5759c25a0ccbf8cf33ba661d5c6839259bc1d61 Mon Sep 17 00:00:00 2001
-From: Frogging-Family
-From: damachine <damachin3@proton.me>
+From 402a66a01876617f084aabf237b5e439ef543acb Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Christian=20K=C3=BChn?= <damachin3@proton.me>
 Date: Wed, 15 Apr 2026 21:55:26 +0200
-Subject: [PATCH] Add compiler optimization option
+Subject: [PATCH] Add O3 compiler optimization options
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 Add CONFIG_CC_OPTIMIZE_FOR_PERFORMANCE_O3 Kconfig option that allows
 building the kernel with -O3 instead of the default -O2.
-Enable swing modulo scheduling (-fmodulo-sched, -fmodulo-sched-allow-regmoves,
--fivopts) for additional loop optimization by overlapping iterations
-of innermost loops.
+
+Enable swing modulo scheduling with the -fmodulo-sched,
+the -fmodulo-sched-allow-regmoves, and the -fivopts flags to improve
+innermost loop optimization by overlapping iterations.
+
 Enable LLVM pipeliner (-mllvm -enable-pipeliner) for additional
 loop pipelining on supported targets.
 
-Signed-off-by: damachine <damachin3@proton.me>
+Remove GCC's stack conservation flag and add the Zen/ClearLinux x86
+vectorization guard used with O3 builds.
 
+Includes compiler-tuning pieces from the Zen patchset and ClearLinux's
+x86 no-vectorization guard.
+
+Signed-off-by: Christian Kühn <damachin3@proton.me>
 ---
- Makefile     | 9 +++++++++
- init/Kconfig | 6 ++++++
- 2 files changed, 15 insertions(+)
+ Makefile          | 14 +++++++++-----
+ arch/x86/Makefile |  2 +-
+ init/Kconfig      |  6 ++++++
+ 3 files changed, 16 insertions(+), 6 deletions(-)
 
 diff --git a/Makefile b/Makefile
-index 36d0a32fb..510119afd 100644
+index bfb47ad8c..ee931c6b5 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -893,11 +893,20 @@ KBUILD_CFLAGS	+= -fno-delete-null-pointer-checks
+@@ -929,16 +929,25 @@ KBUILD_CFLAGS	+= -fno-delete-null-pointer-checks
  ifdef CONFIG_CC_OPTIMIZE_FOR_PERFORMANCE
  KBUILD_CFLAGS += -O2
  KBUILD_RUSTFLAGS += -Copt-level=2
@@ -44,11 +54,41 @@ index 36d0a32fb..510119afd 100644
  # Always set `debug-assertions` and `overflow-checks` because their default
  # depends on `opt-level` and `debug-assertions`, respectively.
  KBUILD_RUSTFLAGS += -Cdebug-assertions=$(if $(CONFIG_RUST_DEBUG_ASSERTIONS),y,n)
+ KBUILD_RUSTFLAGS += -Coverflow-checks=$(if $(CONFIG_RUST_OVERFLOW_CHECKS),y,n)
+ 
+ # Tell gcc to never replace conditional load with a non-conditional one
+ ifdef CONFIG_CC_IS_GCC
+ # gcc-10 renamed --param=allow-store-data-races=0 to
+@@ -1154,11 +1179,6 @@ KBUILD_CFLAGS	+= -fno-strict-overflow
+ # Make sure -fstack-check isn't enabled (like gentoo apparently did)
+ KBUILD_CFLAGS  += -fno-stack-check
+ 
+-# conserve stack if available
+-ifdef CONFIG_CC_IS_GCC
+-KBUILD_CFLAGS   += -fconserve-stack
+-endif
+-
+ # Ensure compilers do not transform certain loops into calls to wcslen()
+ KBUILD_CFLAGS += -fno-builtin-wcslen
+ 
+diff --git a/arch/x86/Makefile b/arch/x86/Makefile
+index 598f17810..a2ef052ce 100644
+--- a/arch/x86/Makefile
++++ b/arch/x86/Makefile
+@@ -73,7 +73,7 @@ export BITS
+ #
+ #    https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53383
+ #
+-KBUILD_CFLAGS += -mno-sse -mno-mmx -mno-sse2 -mno-3dnow -mno-avx -mno-sse4a
++KBUILD_CFLAGS += -mno-sse -mno-mmx -mno-sse2 -mno-3dnow -mno-avx -mno-sse4a -mno-avx2 -fno-tree-vectorize
+ KBUILD_RUSTFLAGS += --target=$(objtree)/scripts/target.json
+ KBUILD_RUSTFLAGS += -Ctarget-feature=-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-avx,-avx2
+ 
 diff --git a/init/Kconfig b/init/Kconfig
-index 7484cd703..a9975a9bd 100644
+index 5230d4879..b57b6ac83 100644
 --- a/init/Kconfig
 +++ b/init/Kconfig
-@@ -1582,6 +1582,12 @@ config CC_OPTIMIZE_FOR_PERFORMANCE
+@@ -1613,6 +1621,12 @@ config CC_OPTIMIZE_FOR_PERFORMANCE
  	  with the "-O2" compiler flag for best performance and most
  	  helpful compile-time warnings.
  
@@ -62,4 +102,4 @@ index 7484cd703..a9975a9bd 100644
  	bool "Optimize for size (-Os)"
  	help
 -- 
-2.53.0
+2.55.0

--- a/linux-tkg-patches/7.2/patchwork/last-successful-check/0013-clang-polly.patch
+++ b/linux-tkg-patches/7.2/patchwork/last-successful-check/0013-clang-polly.patch
@@ -1,0 +1,2 @@
+_patch_branch_hash=71e5926efc30833a6fd756b9358529ac695fa688ae71cd74e31dd274ae1ecf05
+_patch_kernel_tag=v7.2-rc3

--- a/linux-tkg-patches/7.2/patchwork/last-successful-check/0013-optimize_harder_O3.patch
+++ b/linux-tkg-patches/7.2/patchwork/last-successful-check/0013-optimize_harder_O3.patch
@@ -1,2 +1,2 @@
-_patch_branch_hash=5d77e58c279d1daaa95feb0dd01b74cdd44d6ae4530c6f5ef787f8002bb2f5c6
+_patch_branch_hash=492aafbd940b18b817e4b7957805b9874f488cc1463fee588dd8dacd18c86677
 _patch_kernel_tag=v7.2-rc3


### PR DESCRIPTION
This brings in a few newer Zen defaults for the new 7.x kernel line and drops some of the older, more conservative values we were carrying before. These are only suggestions of course, so please treat them as such.

Since 7.x is a new major kernel line, I thought this might be a good point to refresh the `glitched-base` defaults a little. The added Zen bits seem fairly long lived and well tested by now, so carrying them from 7.1/7.2 onward felt reasonable to me.

The maintenance cost should hopefully stay fairly low too, since these are mostly small default/value changes. Also, some of these changes only take effect when the related `_zenify` / `.cfg` options are enabled, so they should not affect everyone unconditionally.

Hope you like the direction. If not, I will only cry a very small, properly rate limited amount. xD

Imported from:

https://github.com/zen-kernel/zen-kernel/commit/a07ceee31a99bc8b29c07ee5183fa39e84b989aa

1. Refreshes `0013-optimize_harder_O3.patch` for 7.1 and 7.2.

I cherry-picked these bits from Zen and added them to O3. (Perhaps the choice of location in O3 isn't ideal; it might be better placed in base/misc.)

- removes GCC `-fconserve-stack` [0006-zen-disable-stack-conservation-for-gcc.patch](https://github.com/damachine/linux-tkg/blob/staging/linux-tkg-patches/7.1/patchwork/zen-split/0006-zen-disable-stack-conservation-for-gcc.patch)
- disables AVX2/tree vectorization on x86 with:`-mno-avx2 -fno-tree-vectorize` [0007-zen-arch-x86-disable-avx2-and-tree-vectorization.patch](https://github.com/damachine/linux-tkg/blob/staging/linux-tkg-patches/7.1/patchwork/zen-split/0007-zen-arch-x86-disable-avx2-and-tree-vectorization.patch)
- adds optional Clang Polly optimization for LLVM O3 builds when `LLVMPolly.so` is available https://github.com/CachyOS/kernel-patches/blob/master/7.1/misc/0001-clang-polly.patch

2. Refreshes `0003-glitched-base.patch` for 7.1 and 7.2.

New Zen patches added:

- [`mm: stop kswapd early when no allocation waiters remain`](https://github.com/damachine/linux-tkg/blob/staging/linux-tkg-patches/7.1/patchwork/zen-split/0015-zen-mm-stop-kswapd-early-when-nothing-s-waiting-for-it-to-free-pages.patch)
- [`mm: disable watermark boosting by default for interactive builds`](https://github.com/damachine/linux-tkg/blob/staging/linux-tkg-patches/7.1/patchwork/zen-split/0027-zen-interactive-mm-disable-watermark-boosting-by-default.patch)
- [`mm/swap: disable swap-in readahead`](https://github.com/damachine/linux-tkg/blob/staging/linux-tkg-patches/7.1/patchwork/zen-split/0028-zen-interactive-mm-swap-disable-swap-in-readahead.patch)
- [`cpufreq: remove the schedutil dependency from Intel/AMD P-State drivers`](https://github.com/damachine/linux-tkg/blob/staging/linux-tkg-patches/7.1/patchwork/zen-split/0012-zen-cpufreq-remove-schedutil-dependency-on-intel-amd-p-state-drivers.patch)
- [`x86: disable split lock mitigation by default for interactive builds`](https://github.com/damachine/linux-tkg/blob/staging/linux-tkg-patches/7.1/patchwork/zen-split/0030-zen-interactive-disable-split-lock-mitigation-by-default.patch)
- [`sched/core: always inline finish_task_switch() and related helpers`](https://github.com/damachine/linux-tkg/blob/staging/linux-tkg-patches/7.1/patchwork/zen-split/0018-zen-sched-core-make-finish-task-switch-and-its-subfunctions-always-inline.patch)
~*I’m not entirely sure about it, though, since it involves changes to the scheduler. As I see it, it shouldn't affect the other schedulers, but I can't say for certain whether there might be a conflict.*~ 
*I tested that with BORE and didn't notice any problems.*

Value changes:

* `max_map_count`: `16777216` -> `INT_MAX - 5`

  Replaced the older two-step TKG `max_map_count` handling (`262144` -> `16777216`) with Zen's style default: `INT_MAX - MAPCOUNT_ELF_CORE_MARGIN`, effectively `2147483642`.

* File readahead: `2M` -> `256K`

  This follows the CachyOS/Zen-style reasoning of doubling the default `VM_READAHEAD_PAGES` from 128K to 256K, increasing throughput a bit without going so far that it hurts latency too much.

* SQ scheduler: `mq-deadline` -> `bfq`

* MQ scheduler: `none` -> `kyber`

* Watermark boost factor: `15000` / `1.5` -> `0` under `CONFIG_ZENIFY`

* Swap-in readahead / `page_cluster`: default auto value -> `0` under `CONFIG_ZENIFY`

* Split lock mitigation: `1` -> `0` under `CONFIG_ZENIFY`

Other patchset changes:

* Updated the Zenify help text to document the new defaults.
* Refreshed/rebased the patchsets for the newer kernel bases:

  * 7.1 checked on v7.1.3
  * 7.2 checked on v7.2-rc2
  
Peace :frog: 
