### PR TITLE
prepare: use kmsg DRM panic screen for LLVM LTO

### DIFF
--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -1050,6 +1050,13 @@ _tkg_srcprep() {
       _disable LTO_CLANG_THIN
       _enable LTO_NONE
     fi
+
+    # QR panic screen needs Rust; use kmsg for llvm/lto builds
+    if [[ "$_lto_mode" == "thin" || "$_lto_mode" == "full" ]]; then
+      scripts/config --set-str "DRM_PANIC_SCREEN" "kmsg"
+      _disable "DRM_PANIC_SCREEN_QR_CODE"
+      _undefine "DRM_PANIC_SCREEN_QR_CODE_URL" "DRM_PANIC_SCREEN_QR_VERSION"
+    fi
   fi
 
   if [ "$_distro" = "Gentoo" ]; then


### PR DESCRIPTION
Damn, I really don’t have enough to do, huh? :P

Small detail, but I think `kmsg` is the more useful fallback here.

The `qr_code` DRM panic screen needs Rust, and Rust is not supported with LLVM/LTO yet. Because of that, the kernel falls back to `user`:

```text
[    0.309020] Unsupported value for CONFIG_DRM_PANIC_SCREEN ('qr_code'), falling back to 'user'
```

Using `kmsg` for LLVM/LTO builds seems more helpful than the plain `user` screen. If the system really hangs or panics, the last kernel messages on the panic screen give at least some hint about what happened.

I only noticed this while going through `dmesg`, so yeah, tiny detail. But it avoids the warning and makes the panic screen a bit more useful if someone ever ends up there.
