### PR TITLE
config: move OpenRGB support to legacy

### DIFF
--- a/customization.cfg
+++ b/customization.cfg
@@ -240,9 +240,6 @@ _custom_commandline="intel_pstate=passive"
 # Selection of Clearlinux patches
 _clear_patches="true"
 
-# Add OpenRGB compatibility for certain i2c controllers - https://gitlab.com/CalcProgrammer1/OpenRGB/-/blob/master/OpenRGB.patch
-_openrgb="true"
-
 # [Gentoo specific] Init system used, 'systemd' or 'script' (OpenRC, runit and other script based systems and managers)
 # Enables CONFIG_GENTOO_LINUX_INIT_SYSTEMD xor CONFIG_GENTOO_LINUX_INIT_SCRIPT
 _gentoo_init="systemd"
@@ -297,6 +294,10 @@ KCPPFLAGS=""
 KRUSTFLAGS=""
 
 #### LEGACY OPTIONS ####
+
+# Add OpenRGB compatibility for certain i2c controllers
+# (Deprecated) support for Nuvoton NCT6775/6776 SMBus controllers - https://gitlab.com/OpenRGBDevelopers/OpenRGB-Wiki/-/blob/stable/OpenRGB-Kernel-Patch.md
+_openrgb="false"
 
 # Upstreamed version of Fsync from Linux 5.16 for previous kernel versions - https://github.com/andrealmeid/futex_waitv_patches
 # ! Only affect 5.13, 5.14 and 5.15 kernel branches. Safely ignored for 5.16 or newer !

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -1036,9 +1036,6 @@ _tkg_srcprep() {
     scripts/config --set-str "CMDLINE" "${_custom_commandline}"
   fi
 
-  # openrgb
-  _module "I2C_NCT6775"
-
   # ccache fix
   if [ "$_noccache" != "true" ]; then
     if { [ "$_distro" = "Arch" ] && pacman -Qq ccache &> /dev/null; } || { [ "$_distro" = "Ubuntu" ] && dpkg -l ccache > /dev/null; }; then
@@ -1758,7 +1755,9 @@ fi
   tkgpatch="$srcdir/0014-OpenRGB.patch"
   if [ -e "$tkgpatch" ]; then
     if [ "$_openrgb" = "true" ]; then
-      _msg="Import OpenRGB patch" && _tkg_patcher
+      _msg="Import OpenRGB patch"
+      _tkg_patcher
+      _module "I2C_NCT6775"
     fi
   fi
 


### PR DESCRIPTION
OpenRGB kernel patch is deprecated. Its AMD SMBus support has been upstream since Linux 5.8, while the remaining Nuvoton SMBus driver is maintained separately as i2c-nct6793-dkms. 
https://gitlab.com/OpenRGBDevelopers/OpenRGB-Wiki/-/blob/stable/OpenRGB-Kernel-Patch.md
https://gitlab.com/CalcProgrammer1/OpenRGB/-/work_items/4221#note_2048005846

I suggest moving the patch to the legacy options and keeping it available for NCT6775/6776 hardware, while disabling it by default. Also fix the inconsistent configuration where `I2C_NCT6775` was enabled even when the OpenRGB patch was disabled.

Maybe it can be removed once it no longer has a supported use case.