### PR TITLE
 _libunwind_replace fails with Gentoo default libgcc runtime

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -214,7 +214,7 @@ if [ "$1" = "install" ]; then
     fi
 
     if [[ "$_install_after_building" = "prompt" ]]; then
-      read -p "Do you want to install the new Kernel ? Y/[n]: " _install
+      read -p "Do you want to install the new Kernel ? [N]/y: " _install
     fi
 
     if [[ "$_install_after_building" =~ ^(Y|y|Yes|yes)$ || "$_install" =~ ^(Y|y|Yes|yes)$ ]]; then
@@ -265,7 +265,7 @@ if [ "$1" = "install" ]; then
     fi
 
     if [[ "$_install_after_building" = "prompt" ]]; then
-      read -p "Do you want to install the new Kernel ? Y/[n]: " _install
+      read -p "Do you want to install the new Kernel ? [N]/y: " _install
     fi
 
     if [[ "$_install_after_building" =~ ^(Y|y|Yes|yes)$ || "$_install" =~ ^(Y|y|Yes|yes)$ ]]; then
@@ -294,7 +294,7 @@ if [ "$1" = "install" ]; then
         warning "By default, system kernel updates will overwrite your custom kernel."
         warning "Adding a lock will prevent this but skip system kernel updates."
         msg2 "You can remove the lock if needed with 'sudo zypper removelock kernel-default-devel kernel-default kernel-devel kernel-syms'"
-        read -p "Would you like to lock system kernel packages ? Y/[n]: " _lock
+        read -p "Would you like to lock system kernel packages ? [N]/y: " _lock
         if [[ "$_lock" =~ ^(Y|y|Yes|yes)$ ]]; then
           sudo zypper addlock kernel-default-devel kernel-default kernel-devel kernel-syms
         fi
@@ -366,7 +366,7 @@ if [ "$1" = "install" ]; then
     echo "    sudo make install"
 
     msg2 "Note: Uninstalling requires manual intervention, use './install.sh uninstall-help' for more information."
-    read -p "Continue ? Y/[n]: " _continue
+    read -p "Continue ? [N]/y: " _continue
 
     if ! [[ "$_continue" =~ ^(Y|y|Yes|yes)$ ]];then
       exit 0
@@ -403,7 +403,7 @@ if [ "$1" = "install" ]; then
       sudo ln -sfn "/usr/src/$_headers_folder_name" "/usr/src/linux"
 
       msg2 "Rebuild kernel modules with \"emerge @module-rebuild\" ?"
-      read -p "Y/[n]: " _continue
+      read -p "[N]/y: " _continue
       if [[ "$_continue" =~ ^(Y|y|Yes|yes)$ ]];then
         sudo emerge @module-rebuild --keep-going
       fi

--- a/install.sh
+++ b/install.sh
@@ -388,26 +388,30 @@ if [ "$1" = "install" ]; then
 
     sudo make modules_install $_STRIP_MODS
 
+    sudo cp "$(make ${llvm_opt} -s image_name)" "/lib/modules/$_kernelname/vmlinuz"
+
     msg2 "Removing modules from source folder in /usr/src/${_kernel_src_gentoo}"
     sudo find . -type f -name '*.ko' -delete
     sudo find . -type f -name '*.ko.cmd' -delete
-
-    msg2 "Installing kernel"
-    sudo make install
-
-    sudo cp "$(make ${llvm_opt} -s image_name)" "/lib/modules/$_kernelname/vmlinuz"
 
     if [ "$_distro" = "Gentoo" ]; then
 
       msg2 "Selecting the kernel source code as default source folder"
       sudo ln -sfn "/usr/src/$_headers_folder_name" "/usr/src/linux"
 
+      # Rebuild external modules before make install so installkernel hooks
+      # can include them in a generated initramfs or UKI.
       msg2 "Rebuild kernel modules with \"emerge @module-rebuild\" ?"
       read -p "[N]/y: " _continue
       if [[ "$_continue" =~ ^(Y|y|Yes|yes)$ ]];then
-        sudo emerge @module-rebuild --keep-going
+        if ! sudo emerge @module-rebuild --keep-going; then
+          warning "External kernel module rebuilds did not complete; continuing with kernel installation."
+        fi
       fi
     fi
+
+    msg2 "Installing kernel"
+    sudo make install
 
   fi
 fi

--- a/install.sh
+++ b/install.sh
@@ -96,9 +96,9 @@ if [ "$1" = "install" ] || [ "$1" = "config" ]; then
   # Run init script that is also run in PKGBUILD, it will define some env vars that we will use
   _tkg_initscript
 
+  # Use LLVM libunwind for Kbuild host tools when requested.
   if [[ "${_compiler}" = "llvm" && "${_distro}" =~ ^(Generic|Gentoo)$ && "${_libunwind_replace}" = "true" ]]; then
-      export LDFLAGS_MODULE="-unwindlib=libunwind"
-      export HOSTLDFLAGS="-unwindlib=libunwind"
+    export HOSTLDFLAGS="-rtlib=compiler-rt -unwindlib=libunwind"
   fi
 
   # Install the needed dependencies if the user wants to install the kernel

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -136,6 +136,7 @@ _frog_banner() {
   plain '    `:sdNNNNNNNNNNNNNNNNNNNNNNNNNds:`'
   plain '       `-+shdNNNNNNNNNNNNNNNdhs+-`'
   plain '             `.-:///////:-.`'
+  plain ''
 }
 
 _undefine() {


### PR DESCRIPTION
Hey 🐸 ❤️

Unless I missed something, what is the intended configuration for `_libunwind_replace`?

Since linux-tkg supports this option, I decided to use it to make the build process more consistent when primarily using LLVM toolchains :D

To do this, I enabled the `llvm-libunwind` USE flag 

```
llvm-core/clang-common llvm-libunwind
llvm-runtimes/clang-runtime llvm-libunwind polly
llvm-runtimes/clang-unwindlib-config llvm-libunwind
```

and set `_libunwind_replace=true`, but Clang still defaults to using `libgcc`.

```text
...
 -> Using modprobed-db
make --no-print-directory -C /DATA/damachine/Projekte/linux-tkg/linux-src-git \
-f /DATA/damachine/Projekte/linux-tkg/linux-src-git/Makefile localmodconfig
make -f ./scripts/Makefile.build obj=scripts/basic
# HOSTCC  scripts/basic/fixdep
  clang -Wp,-MMD,scripts/basic/.fixdep.d -Wall -Wmissing-prototypes -Wstrict-prototypes -O2 -fomit-frame-pointer -std=gnu11   -I ./scripts/include    -unwindlib=libunwind -o scripts/basic/fixdep scripts/basic/fixdep.c   
clang: error: --rtlib=libgcc requires --unwindlib=libgcc
make[2]: *** [scripts/Makefile.host:114: scripts/basic/fixdep] Fehler 1
make[1]: *** [/DATA/damachine/Projekte/linux-tkg/linux-src-git/Makefile:666: scripts_basic] Fehler 2
make: *** [Makefile:248: __sub-make] Fehler 2
 -> exit cleanup done
```

Pairing it with `-rtlib=compiler-rt` in `HOSTLDFLAGS` fixes the `HOSTCC` failure:

```bash
export HOSTLDFLAGS="-rtlib=compiler-rt -unwindlib=libunwind"
```

Enabling Gentoo s `default-compiler-rt` USE flag would also work, but it changes the default for every Clang invocation in that slot and makes `_libunwind_replace` redundant. The toggle should select the compatible runtime pair itself.

And I think `LDFLAGS_MODULE` should also be removed. The kernel and its modules do not link against these userspace runtimes. Since `-rtlib` and `-unwindlib` are Clang driver options, they belong in `HOSTLDFLAGS`, not in flags passed directly to `$(LD)` when linking modules.

---

Found one more small thing in the install flow, so I added it here too.

The prompts now show `[N]/y` to make the default clear. On Gentoo, `make install` now runs after `@module-rebuild`, so out-of-tree modules are available before any configured installkernel hooks regenerate the initramfs or UKI.

Cheers