### PR TITLE
PKGBUILD: provide NTSYNC-MODULE

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -156,11 +156,9 @@ hackbase() {
     'scx-scheds: to use sched-ext schedulers'
     'wireless-regdb: to set the correct wireless channels of your country'
   )
-  if [ -e "${srcdir}/ntsync.rules" ]; then
-    provides=("linux=${pkgver}" "${pkgbase}" KSMBD-MODULE VIRTUALBOX-GUEST-MODULES WIREGUARD-MODULE NTSYNC-MODULE ntsync-header)
-  else
-    provides=("linux=${pkgver}" "${pkgbase}" KSMBD-MODULE VIRTUALBOX-GUEST-MODULES WIREGUARD-MODULE)
-  fi
+  provides=("linux=${pkgver}" "${pkgbase}" KSMBD-MODULE VIRTUALBOX-GUEST-MODULES WIREGUARD-MODULE)
+  [ -e "${srcdir}/ntsync.conf" ] && provides+=(NTSYNC-MODULE)
+  [ -e "${srcdir}/ntsync.rules" ] && provides+=(ntsync-header)
   replaces=(virtualbox-guest-modules-arch wireguard-arch)
 
   cd "$_kernel_work_folder_abs"


### PR DESCRIPTION
Hey sry again but - the latest CachyOS Wine update exposed this through its ntsync dependency. 

Fix: native NTsync only creates `ntsync.conf`, so `NTSYNC-MODULE` was missing. Use it for the module provider and keep `ntsync.rules` for the legacy header. This also avoids duplicating the provider list. cheers ;)

<img width="1854" height="1045" alt="Bildschirmfoto_20260726_040748" src="https://github.com/user-attachments/assets/140e8220-027c-43b3-8cb4-be4311cca6c2" />
