### PR TITLE
prepare: Simplify "exit_cleanup" compiler version logging

### DIFF
--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -2047,10 +2047,10 @@ exit_cleanup() {
   cat /etc/os-release > "$_where"/logs/system-info.txt
   if command -v clang &> /dev/null; then
     echo "#################" >> "$_where"/logs/system-info.txt
-    clang -v >> "$_where"/logs/system-info.txt 2>&1
+    clang --version 2>&1 | head -n1 >> "$_where"/logs/system-info.txt
   fi
   echo "#################" >> "$_where"/logs/system-info.txt
-  gcc -v >> "$_where"/logs/system-info.txt 2>&1
+  gcc --version 2>&1 | head -n1 >> "$_where"/logs/system-info.txt
 }
 
 trap exit_cleanup EXIT


### PR DESCRIPTION
Hi guys <3, hope you’re all doing well!

If i see right on a Gentoo clang default settings, calling `clang -v` inside `exit_cleanup` with `set -e` can cause Clang to link an empty program and exit with code 1.

Im not sure why `install.sh` doesn’t show this, but it could still break things we may have overlooked, such as CI. I noticed it while using tkginstaller, as it reported an error after the installation had already completed. At first, I thought tkginstaller itself was the problem, hehe.

I looked for and tested a cleaner approach and I think this does exactly what we need, it makes the check more robust and avoids a possible exit code 1. `-x c` treats `/dev/null` as empty C input while `-###` prints the commands without running them. What do you think? Cheers :)

<img width="1859" height="1506" alt="Bildschirmfoto_20260809_222305" src="https://github.com/user-attachments/assets/3e70e0d8-6a28-43fa-944b-0a21edc0b9e4" />

