### PR TITLE
pkgbuild: drop "record" - install.sh: use time for make

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -124,7 +124,7 @@ build() {
     _schedtool="command schedtool -B -n 1"
     _ionice="command ionice -n 1"
   fi
-  _runtime=$(
+  (
     if [ -n "$_schedtool" ]; then
       _pid="$(exec bash -c 'echo "$PPID"')"
       $_schedtool "$_pid" ||:
@@ -135,8 +135,7 @@ build() {
     export KCFLAGS
     export KRUSTFLAGS
 
-    time ( make ${_force_all_threads} ${llvm_opt} LOCALVERSION= bzImage modules 2>&1 ) 3>&1 1>&2 2>&3
-    return 0
+    time make ${_force_all_threads} ${llvm_opt} LOCALVERSION= bzImage modules
   )
 }
 

--- a/install.sh
+++ b/install.sh
@@ -196,7 +196,7 @@ if [ "$1" = "install" ]; then
   if [[ "$_distro" =~ ^(Ubuntu|Debian)$ ]]; then
 
     msg2 "Building kernel DEB packages"
-    make ${llvm_opt} -j ${_thread_num} bindeb-pkg LOCALVERSION=-${_kernel_flavor}
+    time make ${llvm_opt} -j ${_thread_num} bindeb-pkg LOCALVERSION=-${_kernel_flavor}
     msg2 "Building successfully finished!"
 
     # Create DEBS folder if it doesn't exist
@@ -247,7 +247,7 @@ if [ "$1" = "install" ]; then
 
     msg2 "Building kernel RPM packages"
     export RPMOPTS="--define '_topdir ${_fedora_work_dir}' --define 'install_mod_strip 1'"
-    make ${llvm_opt} -j ${_thread_num} binrpm-pkg LOCALVERSION="${_extra_ver_str}"
+    time make ${llvm_opt} -j ${_thread_num} binrpm-pkg LOCALVERSION="${_extra_ver_str}"
     msg2 "Building successfully finished!"
 
     # Create RPMS folder if it doesn't exist
@@ -321,7 +321,7 @@ if [ "$1" = "install" ]; then
     fi
 
     msg2 "Building kernel"
-    make ${llvm_opt} -j ${_thread_num}
+    time make ${llvm_opt} -j ${_thread_num}
     msg2 "Build successful"
 
     if [ "$_STRIP" = "true" ]; then

--- a/linux-tkg-config/prepare
+++ b/linux-tkg-config/prepare
@@ -2053,9 +2053,6 @@ exit_cleanup() {
   fi
 
   msg2 'exit cleanup done\n'
-  if [ -n "$_runtime" ]; then
-    msg2 "compilation time : \n$_runtime"
-  fi
 
   [[ -f "$_where"/git_work.log.txt ]] && \
     mv -f "$_where"/git_work.log.txt "$_where"/logs/git_work.log.txt


### PR DESCRIPTION
Howdy! I hope I'm not stepping on anyone's toes if someone was already planning to tackle this ;) but we noticed that makepkg wasn't capturing the build output, so here's my hopfully KISS proposal to keep the build output visible while logging it to `shell-output.log`.

The previous `return 0` could mask a failed build and allow `makepkg` to continue. Was that needed for something i miss(CI)? or can it be dropped? See ya!