### PR TITLE
pkgbuild: package Rust artifacts and unstripped VDSO

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -273,6 +273,12 @@ hackheaders() {
   msg2 "Installing KConfig files..."
   find . -name 'Kconfig*' -exec install -Dm644 {} "$builddir/{}" \;
 
+  if [[ $(scripts/config -s CONFIG_RUST) = y ]]; then
+    msg2 "Installing Rust files..."
+    install -Dt "$builddir/rust" -m644 rust/*.rmeta
+    install -Dt "$builddir/rust" rust/*.so
+  fi
+
   msg2 "Removing unneeded architectures..."
   local arch
   for arch in "$builddir"/arch/*/; do

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -279,6 +279,10 @@ hackheaders() {
     install -Dt "$builddir/rust" rust/*.so
   fi
 
+  msg2 "Installing unstripped VDSO..."
+  make INSTALL_MOD_PATH="$pkgdir/usr" vdso_install \
+    link=  # Suppress build-id symlinks
+
   msg2 "Removing unneeded architectures..."
   local arch
   for arch in "$builddir"/arch/*/; do


### PR DESCRIPTION
Howdy all <3

`CONFIG_RUST=y` was doing its job, but `hackheaders()` quietly left the generated Rust bits behind. This meant external Rust modules couldn't find required prebuilt artifacts such as `rust/libcore.rmeta`.

Package the generated `.rmeta` and `.so` files when Rust is enabled, matching [Arch Linux's kernel packaging](https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/blob/main/PKGBUILD#L214).

Fixes #1243 

:frog: :crab: 